### PR TITLE
fix: skip test reporter for fork PRs

### DIFF
--- a/.github/workflows/build-analysis.yml
+++ b/.github/workflows/build-analysis.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           name: Analysis Unit Tests
           path: analysis/build/test-results/*/*.xml


### PR DESCRIPTION
## Summary
- Fixes the failing "Publish test results" step for fork PRs by skipping it when the PR comes from a fork
- The test reporter requires write permissions which are unavailable for fork PRs due to security restrictions
- Test results are still uploaded as artifacts for all PRs

## Test plan
- [ ] Verify workflow passes on fork PRs
- [ ] Verify test reporter still works on internal PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)