### PR TITLE
feat: add SonarCloud analysis to analysis component

### DIFF
--- a/.github/workflows/build-analysis.yml
+++ b/.github/workflows/build-analysis.yml
@@ -106,3 +106,29 @@ jobs:
           path: analysis/build/test-results/*/*.xml
           reporter: java-junit
           fail-on-error: false
+
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for better analysis relevancy
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: analysis-coverage-${{ github.run_id }}
+          path: analysis/build/reports/jacoco/test
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v5.0.0
+        with:
+          projectBaseDir: analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANALYSIS }}

--- a/.github/workflows/build-visualization.yml
+++ b/.github/workflows/build-visualization.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           name: Visualization Unit Tests
           path: visualization/test-results/*.xml

--- a/analysis/sonar-project.properties
+++ b/analysis/sonar-project.properties
@@ -1,3 +1,5 @@
+sonar.projectKey=maibornwolff-gmbh_DependaCharta_analysis
+sonar.organization=maibornwolff-gmbh
 sonar.qualitygate.wait=true
 sonar.sources=src/main/
 sonar.java.binaries=build/classes


### PR DESCRIPTION
- Add projectKey and organization to analysis/sonar-project.properties

- Add SonarCloud job to build-analysis.yml workflow

- Fix test reporter condition in build-visualization.yml to prevent permission errors on fork PRs

The SonarCloud integration follows the same pattern as the visualization component, using a separate SONAR_TOKEN_ANALYSIS secret and running on both PRs and main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)