### PR TITLE
fix: add bytecode compilation to SonarCloud analysis job

### DIFF
--- a/.github/workflows/build-analysis.yml
+++ b/.github/workflows/build-analysis.yml
@@ -113,11 +113,33 @@ jobs:
     timeout-minutes: 15
     needs: build
 
+    defaults:
+      run:
+        working-directory: analysis
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for better analysis relevancy
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+
+      - name: Build project (for bytecode analysis)
+        run: ./gradlew compileKotlin compileTestKotlin --no-daemon
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
SonarCloud needs compiled bytecode to properly map coverage data to source code. Previously, only the coverage XML report was available, which prevented coverage from being displayed in SonarCloud.

This adds Java/Gradle setup and compiles the Kotlin code before running the SonarCloud scan, ensuring all required artifacts are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)