### PR TITLE
fix: correct lcov coverage filename for SonarCloud analysis

### DIFF
--- a/visualization/ci.karma.conf.js
+++ b/visualization/ci.karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
     coverageReporter: {
       dir: 'coverage',
       reporters: [
-        { type: 'lcovonly', subdir: '.', file: 'lcov.txt' },
+        { type: 'lcovonly', subdir: '.', file: 'lcov.info' },
       ]
     },
     junitReporter: {


### PR DESCRIPTION
Changed karma coverage output filename from 'lcov.txt' to 'lcov.info' to match the expected filename in sonar-project.properties. This fixes the visualization component's coverage not being uploaded to SonarCloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)