### PR TITLE
fix: edge labels not rendering on graph visualization

### DIFF
--- a/plans/fix-edge-numbers-rendering.md
+++ b/plans/fix-edge-numbers-rendering.md
@@ -1,0 +1,273 @@
+# Plan: Fix Edge Numbers/Labels Not Rendering on Graphs
+
+## Problem Statement
+Edge weight numbers (dependency counts) are not displaying on the graph visualization despite:
+- The feature being fully implemented in the codebase
+- The toggle button being checked/tested
+- No JavaScript console errors appearing
+- Tests passing for the label display functionality
+
+## Current Implementation (What Should Work)
+
+### Feature Location
+**File:** `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts:56-81`
+
+The `toCytoscapeEdge` function should display numbers when:
+1. `showLabels` state is `true`
+2. Edge `weight > 1`
+
+**Display Logic:**
+```typescript
+if (showLabels && graphEdge.weight > 1) {
+  elementDefinition.style = {
+    label: graphEdge.weight,
+    'font-size': 20
+  }
+}
+```
+
+### Toggle Control
+- **UI Button:** `visualization/src/app/app.component.html:9`
+- **State Management:** `visualization/src/app/model/State.ts:76-79`
+- **Default:** `showLabels: true`
+
+## Investigation Steps
+
+### 1. Verify Toggle State Persistence
+**Goal:** Confirm that clicking "Toggle Edge Labels" actually updates the state and triggers re-rendering
+
+**Tasks:**
+- Add console logging to `app.component.ts:onToggleEdgeLabelsClick()` to verify button clicks
+- Add console logging to `State.ts` toggle handler to verify state updates
+- Add logging to `elementDefinitionConverter.ts:toCytoscapeEdge()` to log `showLabels` parameter value
+- Run the app and toggle the button while watching console output
+
+**Expected Behavior:** Each toggle should log state changes and trigger converter calls with updated `showLabels` value
+
+**Potential Issues:**
+- State not updating (Action not dispatched)
+- Re-rendering not triggered after state change
+- Cytoscape not being notified of style updates
+
+---
+
+### 2. Verify Edge Weight Values
+**Goal:** Ensure edges have `weight > 1` to trigger label display
+
+**Tasks:**
+- Add console logging to `elementDefinitionConverter.ts:toCytoscapeEdge()` to log each edge's weight
+- Analyze test data or real project data to check weight distribution
+- Verify the analysis component is correctly calculating edge weights
+
+**Expected Behavior:** At least some edges should have `weight > 1`
+
+**Potential Issues:**
+- All edges have `weight === 1` (condition never met)
+- Weight values not being set correctly during graph creation
+- Analysis tool not aggregating duplicate edges properly
+
+---
+
+### 3. Verify Cytoscape Style Application
+**Goal:** Ensure style objects are correctly applied to Cytoscape elements
+
+**Tasks:**
+- Add logging before returning from `toCytoscapeEdge()` to log complete `elementDefinition` with styles
+- Use Cytoscape debugger/inspector to examine element data and styles at runtime
+- Verify `elementDefinition.style` is not being overwritten downstream
+- Check if Cytoscape is re-created vs. updated when state changes
+
+**Expected Behavior:** Elements with labels should have `.style.label` property set
+
+**Potential Issues:**
+- Cytoscape instance being recreated without new styles
+- Styles being overwritten by global stylesheet
+- Style property name mismatch (Cytoscape expects different format)
+
+---
+
+### 4. Check for CSS/Styling Conflicts
+**Goal:** Rule out CSS hiding the rendered labels
+
+**Tasks:**
+- Inspect Cytoscape canvas element styles in browser DevTools
+- Check for `display: none`, `opacity: 0`, or `color: transparent` on edge labels
+- Review Cytoscape global stylesheet configuration
+- Test with forced inline style override
+
+**Expected Behavior:** Labels should be visible with font-size 20px
+
+**Potential Issues:**
+- CSS rule hiding labels
+- Text color matching background color
+- Z-index issue placing labels behind other elements
+
+---
+
+### 5. Test Cytoscape Label Rendering Directly
+**Goal:** Verify Cytoscape can render labels at all
+
+**Tasks:**
+- Create minimal test with hardcoded label in Cytoscape element
+- Add temporary hardcoded label to all edges (bypass conditional logic)
+- Verify Cytoscape version supports label rendering
+
+**Expected Behavior:** Hardcoded labels should always render
+
+**Potential Issues:**
+- Cytoscape version incompatibility
+- Label rendering disabled globally
+- Canvas rendering context issue
+
+---
+
+## Potential Root Causes & Fixes
+
+### Root Cause 1: State Update Not Triggering Re-render
+**Symptoms:** Toggle button doesn't cause graph to update
+
+**Fix:**
+- Ensure `State.copy()` creates new object reference (triggers change detection)
+- Verify Cytoscape service subscribes to state changes
+- Add explicit `.update()` call to Cytoscape after style changes
+
+**Files to Modify:**
+- `visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts`
+- `visualization/src/app/model/State.ts`
+
+---
+
+### Root Cause 2: All Edge Weights Are 1
+**Symptoms:** No labels appear because condition `weight > 1` is never met
+
+**Fix:**
+- Option A: Change condition to `weight >= 1` to show all weights
+- Option B: Improve weight display to show type labels when weight is 1
+- Option C: Fix analysis tool to properly aggregate edge weights
+
+**Files to Modify:**
+- `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts:68`
+- Possibly `analysis/` component for weight calculation
+
+---
+
+### Root Cause 3: Cytoscape Not Receiving Style Updates
+**Symptoms:** Styles defined but not applied to rendered elements
+
+**Fix:**
+- Call `cy.style().update()` after adding elements with new styles
+- Use Cytoscape style property approach instead of inline styles
+- Ensure element definitions are passed correctly to `cy.add()`
+
+**Files to Modify:**
+- `visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts`
+- Consider moving style logic to Cytoscape stylesheet
+
+---
+
+### Root Cause 4: Inline Styles vs. Stylesheet Conflict
+**Symptoms:** Inline element styles being overridden by global stylesheet
+
+**Fix:**
+- Move label styles from `elementDefinition.style` to Cytoscape global stylesheet
+- Use selectors like `edge[weight > 1]` to conditionally apply styles
+- Ensure stylesheet rules have proper specificity
+
+**Files to Modify:**
+- `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts`
+- Create or modify Cytoscape stylesheet configuration
+
+---
+
+### Root Cause 5: Font Not Loaded or Text Color Issue
+**Symptoms:** Labels rendered but invisible
+
+**Fix:**
+- Add explicit `color` property to label style
+- Verify font is loaded
+- Add text outline or background for visibility
+
+**Files to Modify:**
+- `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts:70-72`
+
+---
+
+## Implementation Strategy (TDD Approach)
+
+### Phase 1: Diagnostic Tests
+1. **Write test:** "Should log showLabels state when toggling edge labels"
+2. **Implement:** Add console logging to track state flow
+3. **Run:** Execute and analyze logs
+
+### Phase 2: Fix Root Cause
+Based on diagnostic findings, implement appropriate fix using:
+1. **Red:** Write failing test demonstrating the bug
+2. **Green:** Implement minimal fix to make test pass
+3. **Refactor:** Clean up code while maintaining passing tests
+
+### Phase 3: Integration Testing
+1. **Manual Test:** Run `just frontend` and verify numbers display
+2. **Test Toggle:** Verify button toggles labels on/off
+3. **Test Data:** Analyze sample project with known edge weights > 1
+4. **Visual Regression:** Ensure other graph features still work
+
+### Phase 4: Documentation
+1. Document the fix in commit message
+2. Update tests to prevent regression
+3. Consider adding user-facing documentation about toggle feature
+
+---
+
+## Testing Checklist
+
+- [ ] Unit tests pass for `elementDefinitionConverter.spec.ts`
+- [ ] Toggle button click triggers state change (verified via logs)
+- [ ] State change triggers Cytoscape update (verified via logs)
+- [ ] Edge weights are correctly calculated and > 1 for some edges
+- [ ] Label styles are applied to Cytoscape elements (verified via inspector)
+- [ ] Labels are visible in the rendered graph (manual verification)
+- [ ] Toggle on shows labels, toggle off hides labels
+- [ ] No console errors or warnings
+- [ ] Other graph features (node selection, layout, etc.) still work
+- [ ] Performance is acceptable with labels enabled
+
+---
+
+## Files to Focus On
+
+### Primary Investigation:
+1. `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts` - Label logic
+2. `visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts` - Rendering orchestration
+3. `visualization/src/app/model/State.ts` - State management
+4. `visualization/src/app/app.component.ts` - Toggle handler
+
+### Secondary:
+5. `visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.spec.ts` - Tests
+6. Analysis component - Edge weight calculation (if needed)
+
+---
+
+## Success Criteria
+
+✅ Edge weights (numbers) are visible on graph edges when:
+  - `showLabels` is true
+  - Edge weight > 1
+
+✅ "Toggle Edge Labels" button correctly shows/hides labels
+
+✅ No console errors or warnings
+
+✅ All existing tests continue to pass
+
+✅ Feature works consistently across different analyzed projects
+
+---
+
+## Next Steps
+
+1. Start with **Investigation Step 1** (Verify Toggle State Persistence)
+2. Add diagnostic logging to understand current behavior
+3. Identify root cause based on log analysis
+4. Implement fix following TDD methodology
+5. Verify fix with manual testing
+6. Clean up diagnostic code and commit

--- a/visualization/package-lock.json
+++ b/visualization/package-lock.json
@@ -566,6 +566,7 @@
       "integrity": "sha512-5Vyo/VJ1DrIsAkudFpZj1f7CpCLYuiTzTQksHTiZE18iYsLKRkEC7y9S6+TiHrdD96rhNxL28Pz9FDU4lIBjkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.4.0",
         "eslint-scope": "^8.0.2"
@@ -622,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.7.tgz",
       "integrity": "sha512-i655RaL0zmLE3OESUlDnRNBDRIMW/67nTQvMqP6V1cQ42l2+SMJtREsxmX6cWt55/qvvgeytAA6aBN4aerBl5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -736,6 +738,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.10.tgz",
       "integrity": "sha512-d95C2r3JP11KCahouWmPaxswz/EE7Zn1k8ocoGt70jl33x42Sg96vAHeOpnQ4yfrdA4W7Q+eWB/NqqvAGCzOPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -825,6 +828,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.7.tgz",
       "integrity": "sha512-uf8dXYTJbedk/wudkt2MfbtvN/T97aEZBtOTq8/IFQQZ3722rag6D+Cg76e5hBccROOn+ueGJX2gpxz02phTwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -841,6 +845,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.7.tgz",
       "integrity": "sha512-EouHO15dUsgnFArj0M25R8cOPVoUfiFYSt6iXnMO8+S4dY1fDEmbFqkW5smlP66HL5Gys59Nwb5inejfIWHrLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -854,6 +859,7 @@
       "integrity": "sha512-viZwWlwc1BAqryRJE0Wq2WgAxDaW9fuwtYHYrOWnIn9sy9KemKmR6RmU9VRydrwUROOlqK49R9+RC1wQ6sYwqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -886,6 +892,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.7.tgz",
       "integrity": "sha512-2UuYzC2A5SUtu33tYTN411Wk0WilA+2Uld/GP3O6mragw1O7v/M8pMFmbe9TR5Ah/abRJIocWGlNqeztZmQmrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -911,6 +918,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.7.tgz",
       "integrity": "sha512-uOCGCoqXeAWIlQMWiIeed/W8g8h2tk91YemMI+Ce1VQ/36Xfft40Bouz4eKcvJV6kLXGygdpWjzFGz32CE+3Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -946,6 +954,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.7.tgz",
       "integrity": "sha512-AbLtyR7fVEGDYyrz95dP2pc69J5XIjLLsFNAuNQPzNX02WPoAxtrWrNY6UnTzGoSrCc5F52hiL2Uo6yPZTiJcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1030,6 +1039,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3864,6 +3874,7 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -6443,6 +6454,7 @@
       "integrity": "sha512-jnVe5ULKl6tijxUhvQeNbQG/84fHfg+yMak02cT8QVhBx/F05rAVxCGBYYTh2EKz22D6JF5ktXuNwdx7b9iEGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6602,6 +6614,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -6709,6 +6722,7 @@
       "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6778,6 +6792,7 @@
       "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.46.2",
@@ -7072,6 +7087,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7161,6 +7177,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7828,6 +7845,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -9800,6 +9818,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -10043,6 +10062,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12430,7 +12450,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.12.0.tgz",
       "integrity": "sha512-QqO4pX33GEML5JoGQU6BM5NHKPgEsg+TXp3jCIDek9MbfEp2JUYEFBo9EF1+hegWy/bCHS1m5nP0BOp18G6rVA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -12453,6 +12474,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12617,6 +12639,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -12960,6 +12983,7 @@
       "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13115,6 +13139,7 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -15376,6 +15401,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16327,6 +16353,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -16383,6 +16410,7 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -17641,6 +17669,7 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -17873,7 +17902,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.0.1",
@@ -17963,6 +17993,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17977,6 +18008,7 @@
       "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.46.2",
         "@typescript-eslint/parser": "8.46.2",
@@ -18259,6 +18291,7 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -18393,6 +18426,7 @@
       "integrity": "sha512-4JLXU0tD6OZNVqlwzm3HGEhAHufSiyv+skb7q0d2367VDMzrU1Q/ZeepvkcHH0rZie6uqEtTQQe0OEOOluH3Mg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -18472,6 +18506,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18988,6 +19023,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -19006,7 +19042,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.spec.ts
+++ b/visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.spec.ts
@@ -165,13 +165,16 @@ describe('ElementDefinitionConverter', () => {
 
       // then
       const expected = {
-        data: {id: graphEdge.id, source: "source", target: "target", weight: 1, isCyclic: true, type: 'inheritance'},
-        style: {
-          label : `${convertTypeOfUsage(graphEdge.type)}\n‎ `,
-          'text-rotation': 'autorotate',
-          'text-wrap': 'wrap',
-          'font-size':  12
-        }
+        data: {
+          id: graphEdge.id,
+          source: "source",
+          target: "target",
+          weight: 1,
+          isCyclic: true,
+          type: 'inheritance',
+          typeLabel: `${convertTypeOfUsage(graphEdge.type)}\n‎ `
+        },
+        classes: 'show-labels show-type'
       }
       expect(edge).toEqual(expected)
     })
@@ -198,7 +201,7 @@ describe('ElementDefinitionConverter', () => {
         // then
         const expected = {
           data: {id: graphEdge.id, source: "source", target: "target", weight: 1, isCyclic: true, type: 'inheritance'},
-
+          classes: 'show-labels'
         }
         expect(edge).toEqual(expected)
       })
@@ -213,7 +216,7 @@ describe('ElementDefinitionConverter', () => {
       const edge = toCytoscapeEdges([graphEdge], false, true)[0]
 
       // then
-      expect(edge.style).toBeUndefined()
+      expect(edge.classes).toEqual([])
     })
 
     it('Should label ElementDefiniton with type if showLabels is true and weight is 1', () => {
@@ -227,7 +230,8 @@ describe('ElementDefinitionConverter', () => {
       const edge = toCytoscapeEdges([graphEdge], true, true)[0]
 
       // then
-      expect(edge.style.label).toEqual(`Inherits\n‎ `)
+      expect(edge.data['typeLabel']).toEqual(`Inherits\n‎ `)
+      expect(edge.classes).toEqual('show-labels show-type')
     })
 
     it('Should label ElementDefiniton if showLabels is true and weight is greater than 1', () => {
@@ -240,7 +244,8 @@ describe('ElementDefinitionConverter', () => {
       const edge = toCytoscapeEdges([graphEdge], true, true)[0]
 
       // then
-      expect(edge.style.label).toEqual(5)
+      expect(edge.data['weight']).toEqual(5)
+      expect(edge.classes).toEqual('show-labels')
     })
 
     it('Converts edgeCollection to graphEdges', () => {

--- a/visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts
+++ b/visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts
@@ -62,20 +62,18 @@ function toCytoscapeEdge(graphEdge: Edge, showLabels: boolean, usageTypeMode: bo
       weight: graphEdge.weight,
       isCyclic: graphEdge.isCyclic,
       type: graphEdge.type
-    }
+    },
+    classes: []
   }
 
-  if (showLabels && graphEdge.weight > 1) {
-    elementDefinition.style = {
-      label : graphEdge.weight,
-      'font-size':  20
-    }
-  } else if (showLabels && usageTypeMode && graphEdge.type && graphEdge.type !== 'usage') {
-    elementDefinition.style = {
-      label : `${convertTypeOfUsage(graphEdge.type)}\n‎ `,
-      'text-rotation': 'autorotate',
-      'text-wrap': 'wrap',
-      'font-size':  12
+  // Add classes to control label visibility via stylesheet
+  if (showLabels) {
+    elementDefinition.classes = 'show-labels'
+
+    if (usageTypeMode && graphEdge.type && graphEdge.type !== 'usage') {
+      elementDefinition.classes = 'show-labels show-type'
+      // Add typeLabel to data for stylesheet to use
+      elementDefinition.data['typeLabel'] = `${convertTypeOfUsage(graphEdge.type)}\n‎ `
     }
   }
 

--- a/visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts
+++ b/visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts
@@ -96,10 +96,9 @@ export class CytoscapeService {
     const newEdges = this.createNewEdges(nodesToAddEdgesFor, state)
     cy.remove(cy.edges())
 
-    // remove style to get rid of browser warning in console:
-    // "Setting a `style` bypass at element creation should be done only when absolutely necessary.  Try to use the stylesheet instead."
-    const newEdgesWithoutStyle: ElementDefinition[] = newEdges.map(({style, ...rest}) => rest)
-    cy.add(newEdgesWithoutStyle)
+    // Edges now use classes and data attributes for styling via stylesheet
+    // instead of inline styles, eliminating the need to strip styles
+    cy.add(newEdges)
     cy.layout({name: 'lsmLayout'}).run()
     this.applyFilters(cy, state)
   }

--- a/visualization/src/app/adapter/cytoscape/internal/cytoscapeConfig.ts
+++ b/visualization/src/app/adapter/cytoscape/internal/cytoscapeConfig.ts
@@ -53,6 +53,30 @@ export const cytoscape_style: StylesheetStyle[] =
         'z-index':8,
       }
     },
+    {
+      selector: 'edge.show-labels[weight > 1]',
+      style: {
+        'label': 'data(weight)',
+        'font-size': 20,
+        'color': '#000000',
+        'text-background-color': '#ffffff',
+        'text-background-opacity': 0.8,
+        'text-background-padding': '3px'
+      }
+    },
+    {
+      selector: 'edge.show-labels.show-type[weight = 1][type][type != "usage"]',
+      style: {
+        'label': 'data(typeLabel)',
+        'text-rotation': 'autorotate',
+        'text-wrap': 'wrap',
+        'font-size': 12,
+        'color': '#000000',
+        'text-background-color': '#ffffff',
+        'text-background-opacity': 0.8,
+        'text-background-padding': '3px'
+      }
+    },
     // only loop edges (source = target)
     {
       selector: ':loop',


### PR DESCRIPTION
Fixed edge weight numbers and usage type labels not displaying on graph edges despite toggle button being enabled and tests passing.

Root Cause:
- Edge styles with labels were being calculated correctly in elementDefinitionConverter.ts
- However, cytoscape.service.ts was stripping out ALL style properties before adding edges to Cytoscape (line 101) to avoid browser warnings
- This removed the calculated label styles, preventing labels from rendering

Solution:
- Refactored to use Cytoscape stylesheet approach instead of inline styles
- Added stylesheet rules in cytoscapeConfig.ts for conditional label display:
  * edge.show-labels[weight > 1] displays weight numbers
  * edge.show-labels.show-type displays usage type labels
- Updated elementDefinitionConverter.ts to use CSS classes instead of inline styles
- Removed the line stripping styles from cytoscape.service.ts
- Updated all tests to verify classes/data instead of inline styles

Changes:
- visualization/src/app/adapter/cytoscape/internal/cytoscapeConfig.ts: Added stylesheet rules for edge labels with proper styling
- visualization/src/app/adapter/cytoscape/internal/converter/elementDefinitionConverter.ts: Changed from inline styles to CSS classes + data attributes
- visualization/src/app/adapter/cytoscape/internal/cytoscape.service.ts: Removed style-stripping code, now passes elements with classes directly
- Updated all related tests to match new implementation

Testing:
- All 244 unit tests passing
- Edge labels now properly display when showLabels=true and weight>1
- Toggle button correctly shows/hides labels via CSS class changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)