### PR TITLE
feat: replace edge labels button with toggle switch

### DIFF
--- a/visualization/src/app/app.component.html
+++ b/visualization/src/app/app.component.html
@@ -6,7 +6,7 @@
     </json-loader>
     <filter [selectedFilter]="state.selectedFilter" (filterSelected)="apply($event)"></filter>
     <button (click)="onRestoreNodesClick()">Restore Nodes</button>
-    <button (click)="onToggleEdgeLabelsClick()">Toggle Edge Labels</button>
+    <toggle-button [isOn]="state.showLabels" (toggleChanged)="onToggleEdgeLabels()">Edge Labels</toggle-button>
     <button (click)="onResetViewClick()">Reset View</button>
     <app-version/>
     <toggle-button

--- a/visualization/src/app/app.component.spec.ts
+++ b/visualization/src/app/app.component.spec.ts
@@ -1,5 +1,9 @@
 import {TestBed} from '@angular/core/testing';
 import {AppComponent} from './app.component';
+import {DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {ToggleButtonComponent} from './ui/toggle-button/toggle-button.component';
+import {Action} from './model/Action';
 
 describe('AppComponent', () => {
 
@@ -19,5 +23,80 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app.title).toEqual('visualization');
+  });
+
+  describe('Edge Labels Toggle', () => {
+    it('should render toggle-button component for edge labels', () => {
+      // Arrange
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      // Act
+      const toggleButtons: DebugElement[] = fixture.debugElement.queryAll(By.directive(ToggleButtonComponent));
+      const edgeLabelsToggle = toggleButtons.find(el => el.nativeElement.textContent.trim() === 'Edge Labels');
+
+      // Assert
+      expect(edgeLabelsToggle).toBeTruthy();
+    });
+
+    it('should bind state.showLabels to toggle-button isOn input', () => {
+      // Arrange
+      const fixture = TestBed.createComponent(AppComponent);
+      const component = fixture.componentInstance;
+      component.state = component.state.reduce(new Action.ToggleEdgeLabels()); // Set to false
+      fixture.detectChanges();
+
+      // Act
+      const toggleButtons: DebugElement[] = fixture.debugElement.queryAll(By.directive(ToggleButtonComponent));
+      const edgeLabelsToggle = toggleButtons.find(el => el.nativeElement.textContent.trim() === 'Edge Labels');
+      const toggleComponent = edgeLabelsToggle?.componentInstance as ToggleButtonComponent;
+
+      // Assert
+      expect(toggleComponent.isOn).toBe(false);
+    });
+
+    it('should call onToggleEdgeLabels when toggleChanged emits', () => {
+      // Arrange
+      const fixture = TestBed.createComponent(AppComponent);
+      const component = fixture.componentInstance;
+      spyOn(component, 'onToggleEdgeLabels');
+      fixture.detectChanges();
+
+      // Act
+      const toggleButtons: DebugElement[] = fixture.debugElement.queryAll(By.directive(ToggleButtonComponent));
+      const edgeLabelsToggle = toggleButtons.find(el => el.nativeElement.textContent.trim() === 'Edge Labels');
+      const toggleComponent = edgeLabelsToggle?.componentInstance as ToggleButtonComponent;
+      toggleComponent.toggleChanged.emit();
+
+      // Assert
+      expect(component.onToggleEdgeLabels).toHaveBeenCalled();
+    });
+
+    it('should dispatch ToggleEdgeLabels action when toggle changes', () => {
+      // Arrange
+      const fixture = TestBed.createComponent(AppComponent);
+      const component = fixture.componentInstance;
+      spyOn(component, 'apply');
+      fixture.detectChanges();
+
+      // Act
+      component.onToggleEdgeLabels();
+
+      // Assert
+      expect(component.apply).toHaveBeenCalledWith(jasmine.any(Action.ToggleEdgeLabels));
+    });
+
+    it('should display "Edge Labels" text in toggle button', () => {
+      // Arrange
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      // Act
+      const toggleButtons: DebugElement[] = fixture.debugElement.queryAll(By.directive(ToggleButtonComponent));
+      const edgeLabelsToggle = toggleButtons.find(el => el.nativeElement.textContent.trim() === 'Edge Labels');
+
+      // Assert
+      expect(edgeLabelsToggle?.nativeElement.textContent.trim()).toBe('Edge Labels');
+    });
   });
 });

--- a/visualization/src/app/app.component.ts
+++ b/visualization/src/app/app.component.ts
@@ -45,7 +45,7 @@ export class AppComponent {
     this.apply(new Action.RestoreNodes())
   }
 
-  onToggleEdgeLabelsClick() {
+  onToggleEdgeLabels() {
     this.apply(new Action.ToggleEdgeLabels())
   }
 


### PR DESCRIPTION
Replace the "Toggle Edge Labels" button with a toggle-button component to provide a more intuitive visual switch control. The toggle shows the current state (on/off) and maintains the same position in the menu bar.

- Replace button with toggle-button component in template
- Rename onToggleEdgeLabelsClick() to onToggleEdgeLabels()
- Add comprehensive unit tests for toggle integration
- Bind state.showLabels to toggle's isOn input

🤖 Generated with [Claude Code](https://claude.com/claude-code)