### PR TITLE
fix: remove custom wheelSensitivity to use Cytoscape default

### DIFF
--- a/visualization/src/app/adapter/cytoscape/internal/cytoscapeConfig.ts
+++ b/visualization/src/app/adapter/cytoscape/internal/cytoscapeConfig.ts
@@ -2,9 +2,9 @@ import {StylesheetStyle} from 'cytoscape';
 
 /*
 * For most of them the default are fine: https://js.cytoscape.org/#init-opts/
+* Using default wheelSensitivity (1.0) to ensure consistent zoom behavior across all hardware configurations
 * */
 export const cytoscape_options = {
-  wheelSensitivity: 5.0,
   // data: {...} could be useful for extra info
   // selectionType: 'additive' | 'single -> if the selection of a node should be added to a set of selections or if one node at a time should be selected (default is 'single')
 }


### PR DESCRIPTION
Removes wheelSensitivity: 5.0 configuration to use the default value of 1.0, ensuring consistent zoom behavior across all hardware configurations (mice, trackpads, etc.) and eliminating the Cytoscape warning about custom wheel sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)