### PR TITLE
ci(docker): switch from GHCR to Docker Hub

### DIFF
--- a/.github/workflows/docker-analysis.yml
+++ b/.github/workflows/docker-analysis.yml
@@ -42,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: dependacharta/dependacharta-analysis
+          images: maibornwolff/dependacharta-analysis
           tags: |
             # Manual dispatch: custom tag
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
- Publish images to dependacharta/dependacharta-analysis on Docker Hub
- Use DOCKER_USERNAME and DOCKER_TOKEN secrets for authentication
- Enable Docker native provenance attestation
- Trigger on version tags (v*.*.* or *.*.*) and manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)