### PR TITLE
fix(analysis): include parent class in nested type paths

### DIFF
--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/model/NodeTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/model/NodeTest.kt
@@ -138,4 +138,125 @@ class NodeTest {
         Assertions.assertThat(paths).containsExactlyInAnyOrder(anotherBookPath)
         Assertions.assertThat(usedTypes.map { it.name }).containsExactlyInAnyOrder("Book")
     }
+
+    @Test
+    fun `should resolve qualified nested class types accessed via parent class`() {
+        // Simulates: ExtractionStrategy.AllChildrenByType("identifier")
+        // where AllChildrenByType is a nested class inside ExtractionStrategy
+        val parentPath = Path("de.extraction.ExtractionStrategy".split("."))
+        val nestedPath = Path("de.extraction.ExtractionStrategy.AllChildrenByType".split("."))
+        val extractionImport = Path("de.extraction.ExtractionStrategy".split("."))
+
+        val projectDictionary = mapOf(
+            "ExtractionStrategy" to listOf(parentPath),
+            "AllChildrenByType" to listOf(nestedPath)
+        )
+        val languageDictionary = emptyMap<String, Path>()
+
+        val node = Node(
+            pathWithName = Path(listOf("de", "consumer", "JavaExtractionDictionary")),
+            physicalPath = "./path",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.KOTLIN,
+            dependencies = setOf(Dependency(extractionImport)),
+            usedTypes = setOf(
+                // This is what gets extracted from: ExtractionStrategy.AllChildrenByType("identifier")
+                Type.simple("ExtractionStrategy.AllChildrenByType"),
+                Type.simple("ExtractionStrategy")
+            )
+        )
+
+        // when
+        val resolvedNode = node.resolveTypes(
+            projectDictionary,
+            languageDictionary,
+            setOf(parentPath.withDots(), nestedPath.withDots())
+        )
+
+        // then
+        val internalDeps = resolvedNode.resolvedNodeDependencies.internalDependencies
+        // Should resolve both the parent and nested class as dependencies
+        Assertions.assertThat(internalDeps.map { it.path }).containsExactlyInAnyOrder(parentPath, nestedPath)
+    }
+
+    @Test
+    fun `should resolve nested class when qualified name matches parent import path`() {
+        // Edge case: When using Parent.Nested, the qualified name starts with the imported parent
+        val parentPath = Path("pkg.Parent".split("."))
+        val nestedPath = Path("pkg.Parent.Nested".split("."))
+
+        val projectDictionary = mapOf(
+            "Parent" to listOf(parentPath),
+            "Nested" to listOf(nestedPath)
+        )
+        val languageDictionary = emptyMap<String, Path>()
+
+        val node = Node(
+            pathWithName = Path(listOf("consumer", "Consumer")),
+            physicalPath = "./path",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.KOTLIN,
+            dependencies = setOf(Dependency(parentPath)), // import pkg.Parent
+            usedTypes = setOf(Type.simple("Parent.Nested"))
+        )
+
+        // when
+        val resolvedNode = node.resolveTypes(
+            projectDictionary,
+            languageDictionary,
+            setOf(parentPath.withDots(), nestedPath.withDots())
+        )
+
+        // then
+        val internalDeps = resolvedNode.resolvedNodeDependencies.internalDependencies
+        Assertions.assertThat(internalDeps.map { it.path }).contains(nestedPath)
+    }
+
+    @Test
+    fun `should resolve sealed class nested type - real world JavaExtractionDictionary case`() {
+        // Exact scenario from TreesitterLibrary (after fix):
+        // - ExtractionStrategy sealed class at: de.maibornwolff.treesitter.excavationsite.extraction.ExtractionStrategy
+        // - AllChildrenByType nested class at: de.maibornwolff.treesitter.excavationsite.extraction.ExtractionStrategy.AllChildrenByType
+        //   (now includes parent class in path)
+        // - JavaExtractionDictionary imports ExtractionStrategy and uses ExtractionStrategy.AllChildrenByType(...)
+
+        val extractionStrategyPath = Path("de.maibornwolff.treesitter.excavationsite.extraction.ExtractionStrategy".split("."))
+        // After fix: nested class path includes parent class
+        val allChildrenByTypePath = Path("de.maibornwolff.treesitter.excavationsite.extraction.ExtractionStrategy.AllChildrenByType".split("."))
+
+        val projectDictionary = mapOf(
+            "ExtractionStrategy" to listOf(extractionStrategyPath),
+            "AllChildrenByType" to listOf(allChildrenByTypePath)
+        )
+        val languageDictionary = emptyMap<String, Path>()
+
+        val node = Node(
+            pathWithName = Path("de.maibornwolff.treesitter.excavationsite.languages.java.extraction.JavaExtractionDictionary".split(".")),
+            physicalPath = "./path",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.KOTLIN,
+            dependencies = setOf(Dependency(extractionStrategyPath)), // import ExtractionStrategy
+            usedTypes = setOf(
+                Type.simple("ExtractionStrategy.AllChildrenByType"),
+                Type.simple("ExtractionStrategy"),
+                Type.simple("Map")
+            )
+        )
+
+        // when
+        val resolvedNode = node.resolveTypes(
+            projectDictionary,
+            languageDictionary,
+            setOf(extractionStrategyPath.withDots(), allChildrenByTypePath.withDots())
+        )
+
+        // then
+        val internalDeps = resolvedNode.resolvedNodeDependencies.internalDependencies
+
+        // Should resolve BOTH ExtractionStrategy AND AllChildrenByType as dependencies
+        Assertions.assertThat(internalDeps.map { it.path.withDots() }).containsExactlyInAnyOrder(
+            extractionStrategyPath.withDots(),
+            allChildrenByTypePath.withDots()
+        )
+    }
 }


### PR DESCRIPTION
Nested classes like `ExtractionStrategy.AllChildrenByType` were being registered with incorrect paths (e.g., `pkg.AllChildrenByType` instead of `pkg.ExtractionStrategy.AllChildrenByType`), causing inbound dependencies to not resolve correctly.

Added `findParentClassPath()` to traverse AST and find parent class declarations when constructing the full path for nested types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)