### PR TITLE
style(analysis): fix ktlint violations in TypeScript config files

### DIFF
--- a/analysis/.editorconfig
+++ b/analysis/.editorconfig
@@ -10,6 +10,7 @@ ktlint_standard_string-template-indent = disabled
 ktlint_standard_supertype-list-wrapping = disabled
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_function-expression-body = disabled
 
 [build.gradle.kts]
 max_line_length = off

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/PathAliasResolver.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/PathAliasResolver.kt
@@ -36,7 +36,10 @@ object PathAliasResolver {
         return Path(relativePath.split("/").filter { it.isNotEmpty() })
     }
 
-    private fun findMatchingPath(importPath: String, paths: Map<String, List<String>>?): String? {
+    private fun findMatchingPath(
+        importPath: String,
+        paths: Map<String, List<String>>?
+    ): String? {
         if (paths == null) {
             return null
         }
@@ -65,7 +68,10 @@ object PathAliasResolver {
         return baseUrl.removePrefix("./").removeSuffix("/")
     }
 
-    private fun makeRelativeToAnalysisRoot(absolutePath: File, analysisRoot: File): String {
+    private fun makeRelativeToAnalysisRoot(
+        absolutePath: File,
+        analysisRoot: File
+    ): String {
         val canonicalAnalysisRoot = analysisRoot.canonicalFile
         val absolutePathStr = absolutePath.path
         val analysisRootStr = canonicalAnalysisRoot.path

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigResolver.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigResolver.kt
@@ -57,7 +57,10 @@ class TsConfigResolver {
         return mergeConfigs(parentConfig, config)
     }
 
-    private fun resolveExtendsPath(tsconfigFile: File, extendsPath: String): File {
+    private fun resolveExtendsPath(
+        tsconfigFile: File,
+        extendsPath: String
+    ): File {
         return if (File(extendsPath).isAbsolute) {
             File(extendsPath)
         } else {
@@ -65,7 +68,10 @@ class TsConfigResolver {
         }
     }
 
-    private fun mergeConfigs(parent: TsConfigData, child: TsConfigData): TsConfigData {
+    private fun mergeConfigs(
+        parent: TsConfigData,
+        child: TsConfigData
+    ): TsConfigData {
         val parentOptions = parent.compilerOptions
         val childOptions = child.compilerOptions
 

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/PathAliasResolverTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/PathAliasResolverTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class PathAliasResolverTest {
-
     @Test
     fun `should resolve simple path alias without wildcard`() {
         // given

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigParserTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigParserTest.kt
@@ -13,7 +13,8 @@ class TsConfigParserTest {
     fun `should parse tsconfig with baseUrl and paths`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "src",
@@ -23,7 +24,8 @@ class TsConfigParserTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -39,13 +41,15 @@ class TsConfigParserTest {
     fun `should parse tsconfig with only baseUrl`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "./src"
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -60,7 +64,8 @@ class TsConfigParserTest {
     fun `should parse tsconfig with only paths`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "paths": {
@@ -68,7 +73,8 @@ class TsConfigParserTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -83,16 +89,19 @@ class TsConfigParserTest {
     fun `should parse tsconfig with extends field`() {
         // given
         val parentTsconfig = tempDir.resolve("tsconfig.base.json")
-        parentTsconfig.writeText("""
+        parentTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "."
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "./tsconfig.base.json",
               "compilerOptions": {
@@ -101,7 +110,8 @@ class TsConfigParserTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -128,13 +138,15 @@ class TsConfigParserTest {
     fun `should return null for malformed JSON`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "src"
               invalid json
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -162,12 +174,14 @@ class TsConfigParserTest {
     fun `should parse tsconfig without compilerOptions`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "include": ["src/**/*"],
               "exclude": ["node_modules"]
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)
@@ -181,7 +195,8 @@ class TsConfigParserTest {
     fun `should handle multiple path mappings for same pattern`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": ".",
@@ -190,7 +205,8 @@ class TsConfigParserTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         // when
         val result = TsConfigParser.parse(tsconfig)

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigResolverTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/typescript/tsconfig/TsConfigResolverTest.kt
@@ -22,13 +22,15 @@ class TsConfigResolverTest {
         // given
         val srcDir = tempDir.resolve("src").apply { mkdirs() }
         val tsconfig = srcDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "."
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = srcDir.resolve("index.ts")
 
@@ -44,13 +46,15 @@ class TsConfigResolverTest {
     fun `should find tsconfig in parent directory`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "src"
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val srcDir = tempDir.resolve("src/components").apply { mkdirs() }
         val sourceFile = srcDir.resolve("App.ts")
@@ -67,23 +71,27 @@ class TsConfigResolverTest {
     fun `should prefer nearest tsconfig in monorepo`() {
         // given
         val rootTsconfig = tempDir.resolve("tsconfig.json")
-        rootTsconfig.writeText("""
+        rootTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "."
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val packagesDir = tempDir.resolve("packages/frontend").apply { mkdirs() }
         val packageTsconfig = packagesDir.resolve("tsconfig.json")
-        packageTsconfig.writeText("""
+        packageTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "src"
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = packagesDir.resolve("src/index.ts")
 
@@ -112,17 +120,20 @@ class TsConfigResolverTest {
     fun `should resolve tsconfig with extends field`() {
         // given
         val baseTsconfig = tempDir.resolve("tsconfig.base.json")
-        baseTsconfig.writeText("""
+        baseTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": ".",
                 "strict": true
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "./tsconfig.base.json",
               "compilerOptions": {
@@ -131,7 +142,8 @@ class TsConfigResolverTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = tempDir.resolve("src/index.ts")
 
@@ -148,7 +160,8 @@ class TsConfigResolverTest {
     fun `should resolve extends to merged configuration`() {
         // given
         val baseTsconfig = tempDir.resolve("tsconfig.base.json")
-        baseTsconfig.writeText("""
+        baseTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": ".",
@@ -157,10 +170,12 @@ class TsConfigResolverTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "./tsconfig.base.json",
               "compilerOptions": {
@@ -169,7 +184,8 @@ class TsConfigResolverTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = tempDir.resolve("src/index.ts")
 
@@ -186,23 +202,27 @@ class TsConfigResolverTest {
     fun `should override parent baseUrl with child baseUrl`() {
         // given
         val baseTsconfig = tempDir.resolve("tsconfig.base.json")
-        baseTsconfig.writeText("""
+        baseTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "."
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "./tsconfig.base.json",
               "compilerOptions": {
                 "baseUrl": "src"
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = tempDir.resolve("index.ts")
 
@@ -218,16 +238,19 @@ class TsConfigResolverTest {
     fun `should handle extends with absolute path`() {
         // given
         val baseTsconfig = tempDir.resolve("config/tsconfig.base.json").apply { parentFile.mkdirs() }
-        baseTsconfig.writeText("""
+        baseTsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "."
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "${baseTsconfig.absolutePath}",
               "compilerOptions": {
@@ -236,7 +259,8 @@ class TsConfigResolverTest {
                 }
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = tempDir.resolve("src/index.ts")
 
@@ -253,11 +277,13 @@ class TsConfigResolverTest {
     fun `should return null for extends with non-existent file`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "extends": "./nonexistent.json"
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val sourceFile = tempDir.resolve("src/index.ts")
 
@@ -273,13 +299,15 @@ class TsConfigResolverTest {
     fun `should cache tsconfig lookups for performance`() {
         // given
         val tsconfig = tempDir.resolve("tsconfig.json")
-        tsconfig.writeText("""
+        tsconfig.writeText(
+            """
             {
               "compilerOptions": {
                 "baseUrl": "src"
               }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val file1 = tempDir.resolve("src/file1.ts")
         val file2 = tempDir.resolve("src/file2.ts")


### PR DESCRIPTION
- Disable ktlint_standard_function-expression-body rule to align with project coding guidelines
- Fix parameter-list-wrapping for functions with long parameter lists
- Auto-format test files to resolve newline and indentation violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)