### PR TITLE
fix(ci): pass project version to SonarCloud to fix stale new code bas…

### DIFF
--- a/.github/workflows/build-analysis.yml
+++ b/.github/workflows/build-analysis.yml
@@ -149,10 +149,22 @@ jobs:
           name: analysis-coverage-${{ github.run_id }}
           path: analysis/build/reports/jacoco/test
 
+      - name: Determine version for SonarCloud
+        id: sonar-version
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+            echo "version=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          fi
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v5.0.0
         with:
           projectBaseDir: analysis
+          args: >
+            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANALYSIS }}

--- a/.github/workflows/build-visualization.yml
+++ b/.github/workflows/build-visualization.yml
@@ -201,10 +201,22 @@ jobs:
           name: coverage-${{ github.run_id }}
           path: visualization/coverage
 
+      - name: Determine version for SonarCloud
+        id: sonar-version
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+            echo "version=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          fi
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v5.0.0
         with:
           projectBaseDir: visualization
+          args: >
+            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_VISUALIZATION }}

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
@@ -1,9 +1,15 @@
 package de.maibornwolff.dependacharta.pipeline.analysis.analyzers
 
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.cpp.CppAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.csharp.CSharpAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.golang.GoAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.java.JavaAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.javascript.JavascriptAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.kotlin.KotlinAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.php.PhpAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.python.PythonAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.typescript.TypescriptAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.vue.VueAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
 import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
 import org.assertj.core.api.Assertions.assertThat
@@ -36,11 +42,47 @@ class LanguageAnalyzerFactoryTest {
                 physicalPath = "",
                 content = ""
             )
+            val javascriptFileInfo = FileInfo(
+                language = SupportedLanguage.JAVASCRIPT,
+                physicalPath = "",
+                content = ""
+            )
+            val phpFileInfo = FileInfo(
+                language = SupportedLanguage.PHP,
+                physicalPath = "",
+                content = ""
+            )
+            val goFileInfo = FileInfo(
+                language = SupportedLanguage.GO,
+                physicalPath = "",
+                content = ""
+            )
+            val pythonFileInfo = FileInfo(
+                language = SupportedLanguage.PYTHON,
+                physicalPath = "",
+                content = ""
+            )
+            val cppFileInfo = FileInfo(
+                language = SupportedLanguage.CPP,
+                physicalPath = "",
+                content = ""
+            )
+            val vueFileInfo = FileInfo(
+                language = SupportedLanguage.VUE,
+                physicalPath = "",
+                content = ""
+            )
             return listOf(
                 Arguments.of(javaFileInfo, JavaAnalyzer(javaFileInfo)),
                 Arguments.of(cSharpFileInfo, CSharpAnalyzer(cSharpFileInfo)),
                 Arguments.of(typescriptFileInfo, TypescriptAnalyzer(typescriptFileInfo)),
-                Arguments.of(kotlinFileInfo, KotlinAnalyzer(kotlinFileInfo))
+                Arguments.of(kotlinFileInfo, KotlinAnalyzer(kotlinFileInfo)),
+                Arguments.of(javascriptFileInfo, JavascriptAnalyzer(javascriptFileInfo)),
+                Arguments.of(phpFileInfo, PhpAnalyzer(phpFileInfo)),
+                Arguments.of(goFileInfo, GoAnalyzer(goFileInfo)),
+                Arguments.of(pythonFileInfo, PythonAnalyzer(pythonFileInfo)),
+                Arguments.of(cppFileInfo, CppAnalyzer(cppFileInfo)),
+                Arguments.of(vueFileInfo, VueAnalyzer(vueFileInfo))
             )
         }
     }

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverServiceTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverServiceTest.kt
@@ -257,6 +257,8 @@ class DependencyResolverServiceTest {
         val serverResolved = resolvedNodes.first { it.pathWithName.parts.last() == "Server" }
         assertThat(serverResolved.resolvedNodeDependencies.internalDependencies)
             .containsExactly(Dependency(handler.pathWithName))
+        assertThat(serverResolved.resolvedNodeDependencies.externalDependencies)
+            .isEmpty()
     }
 
     @Test
@@ -271,8 +273,8 @@ class DependencyResolverServiceTest {
                 Dependency(Path(listOf("MyApp", "Services")), true),
             ),
             usedTypes = setOf(
-                Type("String", TypeOfUsage.USAGE, emptyList()),
-                Type("List", TypeOfUsage.USAGE, emptyList()),
+                Type("string", TypeOfUsage.USAGE, emptyList()),
+                Type("bool", TypeOfUsage.USAGE, emptyList()),
                 Type("UserRepository", TypeOfUsage.USAGE, emptyList())
             ),
         )
@@ -297,6 +299,8 @@ class DependencyResolverServiceTest {
         val serviceResolved = resolvedNodes.first { it.pathWithName.parts.last() == "UserService" }
         assertThat(serviceResolved.resolvedNodeDependencies.internalDependencies)
             .containsExactly(Dependency(repository.pathWithName))
+        assertThat(serviceResolved.resolvedNodeDependencies.externalDependencies)
+            .isEmpty()
     }
 
     @Test

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverServiceTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverServiceTest.kt
@@ -220,6 +220,86 @@ class DependencyResolverServiceTest {
     }
 
     @Test
+    fun `should resolve Go node and filter out standard library types`() {
+        // Arrange
+        val goStruct = Node.build(
+            pathWithName = Path(listOf("myapp", "handler", "Server")),
+            physicalPath = "handler/server.go",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.GO,
+            dependencies = setOf(
+                Dependency(Path(listOf("myapp", "handler")), true),
+            ),
+            usedTypes = setOf(
+                Type("error", TypeOfUsage.USAGE, emptyList()),
+                Type("string", TypeOfUsage.USAGE, emptyList()),
+                Type("Handler", TypeOfUsage.USAGE, emptyList())
+            ),
+        )
+
+        val handler = Node.build(
+            pathWithName = Path(listOf("myapp", "handler", "Handler")),
+            physicalPath = "handler/handler.go",
+            nodeType = NodeType.INTERFACE,
+            language = SupportedLanguage.GO,
+            dependencies = setOf(
+                Dependency(Path(listOf("myapp", "handler")), true),
+            ),
+            usedTypes = setOf(),
+        )
+
+        val report = FileReport(nodes = listOf(goStruct, handler))
+
+        // Act
+        val resolvedNodes = DependencyResolverService.resolveNodes(listOf(report))
+
+        // Assert
+        val serverResolved = resolvedNodes.first { it.pathWithName.parts.last() == "Server" }
+        assertThat(serverResolved.resolvedNodeDependencies.internalDependencies)
+            .containsExactly(Dependency(handler.pathWithName))
+    }
+
+    @Test
+    fun `should resolve C# node and filter out standard library types`() {
+        // Arrange
+        val csClass = Node.build(
+            pathWithName = Path(listOf("MyApp", "Services", "UserService")),
+            physicalPath = "Services/UserService.cs",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.C_SHARP,
+            dependencies = setOf(
+                Dependency(Path(listOf("MyApp", "Services")), true),
+            ),
+            usedTypes = setOf(
+                Type("String", TypeOfUsage.USAGE, emptyList()),
+                Type("List", TypeOfUsage.USAGE, emptyList()),
+                Type("UserRepository", TypeOfUsage.USAGE, emptyList())
+            ),
+        )
+
+        val repository = Node.build(
+            pathWithName = Path(listOf("MyApp", "Services", "UserRepository")),
+            physicalPath = "Services/UserRepository.cs",
+            nodeType = NodeType.CLASS,
+            language = SupportedLanguage.C_SHARP,
+            dependencies = setOf(
+                Dependency(Path(listOf("MyApp", "Services")), true),
+            ),
+            usedTypes = setOf(),
+        )
+
+        val report = FileReport(nodes = listOf(csClass, repository))
+
+        // Act
+        val resolvedNodes = DependencyResolverService.resolveNodes(listOf(report))
+
+        // Assert
+        val serviceResolved = resolvedNodes.first { it.pathWithName.parts.last() == "UserService" }
+        assertThat(serviceResolved.resolvedNodeDependencies.internalDependencies)
+            .containsExactly(Dependency(repository.pathWithName))
+    }
+
+    @Test
     fun `Maps Node to NodeInformation`() {
         // given
         val node = Node.build(

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/levelization/model/GraphNodeTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/processing/levelization/model/GraphNodeTest.kt
@@ -5,6 +5,8 @@ import de.maibornwolff.dependacharta.pipeline.processing.model.EdgeInfoDto
 import de.maibornwolff.dependacharta.pipeline.processing.model.ProjectNodeDto
 import de.maibornwolff.dependacharta.pipeline.processing.model.build
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class GraphNodeTest {
@@ -117,5 +119,55 @@ class GraphNodeTest {
         )
 
         assertThat(projectNodeDto).isEqualTo(expected)
+    }
+
+    @Nested
+    inner class WrapInVirtualRootIfNeeded {
+        @Test
+        fun `should return single root unchanged`() {
+            // Arrange
+            val root = GraphNode(id = "com.example", parent = null, children = emptyList())
+
+            // Act
+            val (nodes, resultRoot) = GraphNode.wrapInVirtualRootIfNeeded(listOf(root))
+
+            // Assert
+            assertThat(nodes).hasSize(1)
+            assertThat(resultRoot).isEqualTo(root)
+        }
+
+        @Test
+        fun `should wrap multiple roots in virtual root`() {
+            // Arrange
+            val root1 = GraphNode(id = "com.first", parent = null, children = emptyList())
+            val root2 = GraphNode(id = "com.second", parent = null, children = emptyList())
+
+            // Act
+            val (nodes, virtualRoot) = GraphNode.wrapInVirtualRootIfNeeded(listOf(root1, root2))
+
+            // Assert
+            assertThat(virtualRoot.id).isEqualTo("__virtual_root__")
+            assertThat(virtualRoot.parent).isNull()
+            assertThat(virtualRoot.children).hasSize(2)
+            assertThat(nodes).allMatch { it.parent == "__virtual_root__" }
+        }
+
+        @Test
+        fun `should throw on empty list`() {
+            // Act & Assert
+            assertThatThrownBy { GraphNode.wrapInVirtualRootIfNeeded(emptyList()) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `should throw when nodes already have parents`() {
+            // Arrange
+            val node1 = GraphNode(id = "child", parent = "some.parent", children = emptyList())
+            val node2 = GraphNode(id = "root", parent = null, children = emptyList())
+
+            // Act & Assert
+            assertThatThrownBy { GraphNode.wrapInVirtualRootIfNeeded(listOf(node1, node2)) }
+                .isInstanceOf(IllegalStateException::class.java)
+        }
     }
 }


### PR DESCRIPTION
…eline

SonarCloud was never receiving sonar.projectVersion, causing the "New Code" baseline to be stuck at November 2025. This inflated the new code window with unrelated files and caused false coverage failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflows now compute a project version from git tags (with a fallback) and pass it to SonarCloud scans.
* **Tests**
  * Added unit tests covering language analyzer coverage for more languages, dependency-resolution behavior across languages, and graph-node root-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->