### PR TITLE
feat(analysis): add Delphi language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Delphi dependency analysis support (`.pas`, `.dpr` files)
+
 ## [0.23.0] - 2026-04-17
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ For a detailed explanation of DependaCharta's domain concepts, see our [Domain M
 ### Key Technologies
 - **Analysis**: Kotlin, Tree-sitter, Gradle, Clikt CLI framework
 - **Visualization**: Angular 20, TypeScript, Cytoscape.js, Electron
-- **Supported Languages**: Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue
+- **Supported Languages**: Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi
 
 ### Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The Analysis component is a command-line tool that analyzes codebases using [Tre
 - Dependencies between files and packages
 - Cycle detection with detailed cycle information
 - Levelization for architectural insights
-- Support for multiple programming languages: **Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue**
+- Support for multiple programming languages: **Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi**
 
 Don't see your language? You can [extend the supported languages](analysis/howto-add-new-language.md) by adding a new parser!
 

--- a/analysis/build.gradle.kts
+++ b/analysis/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.6.0")
+    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.7.0")
     implementation("io.github.bonede:tree-sitter:0.26.3")
     implementation("io.github.bonede:tree-sitter-c-sharp:0.23.1")
     implementation("io.github.bonede:tree-sitter-cpp:0.23.4")

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactory.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactory.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.dependacharta.pipeline.analysis.analyzers
 
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.cpp.CppAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.csharp.CSharpAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.delphi.DelphiAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.golang.GoAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.java.JavaAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.javascript.JavascriptAnalyzer
@@ -27,6 +28,7 @@ class LanguageAnalyzerFactory {
                 SupportedLanguage.CPP -> CppAnalyzer(fileInfo)
                 SupportedLanguage.KOTLIN -> KotlinAnalyzer(fileInfo)
                 SupportedLanguage.VUE -> VueAnalyzer(fileInfo)
+                SupportedLanguage.DELPHI -> DelphiAnalyzer(fileInfo)
             }
     }
 }

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/delphi/DelphiAnalyzer.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/delphi/DelphiAnalyzer.kt
@@ -1,0 +1,20 @@
+package de.maibornwolff.dependacharta.pipeline.analysis.analyzers.delphi
+
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.BaseLanguageAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Path
+import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
+import de.maibornwolff.treesitter.excavationsite.api.Declaration
+
+class DelphiAnalyzer(
+    fileInfo: FileInfo,
+) : BaseLanguageAnalyzer(fileInfo) {
+    override val language = SupportedLanguage.DELPHI
+
+    override fun buildPathWithName(
+        packagePath: List<String>,
+        declaration: Declaration,
+    ): Path {
+        return Path(packagePath + declaration.parentPath + declaration.name)
+    }
+}

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverService.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverService.kt
@@ -39,6 +39,7 @@ class DependencyResolverService {
                 SupportedLanguage.CPP -> CppStandardLibrary()
                 SupportedLanguage.KOTLIN -> KotlinStandardLibrary()
                 SupportedLanguage.VUE -> EmptyStandardLibrary()
+                SupportedLanguage.DELPHI -> EmptyStandardLibrary()
             }
     }
 }

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguage.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguage.kt
@@ -14,6 +14,7 @@ enum class SupportedLanguage(
     CPP("C++", listOf("cpp", "c", "cc", "cxx", "h", "hpp", "hxx", "hh")),
     KOTLIN("Kotlin", listOf("kt", "kts")),
     VUE("Vue", listOf("vue")),
+    DELPHI("Delphi", listOf("pas", "dpr")),
 }
 
 fun languagesByExtension(languages: List<SupportedLanguage>) =

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/DelphiAnalyzerTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/DelphiAnalyzerTest.kt
@@ -1,0 +1,343 @@
+package de.maibornwolff.dependacharta.pipeline.analysis.analyzers
+
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.delphi.DelphiAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Dependency
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Path
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Type
+import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DelphiAnalyzerTest {
+    private fun analyze(code: String) = DelphiAnalyzer(FileInfo(SupportedLanguage.DELPHI, "./path", code)).analyze()
+
+    @Test
+    fun `should extract dotted unit name as package path`() {
+        // Given
+        val code = """
+            unit MyCo.Utils;
+            interface
+            type
+              THelper = class
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val parts = report.nodes
+            .first()
+            .pathWithName.parts
+        assertThat(parts).containsExactly("MyCo", "Utils", "THelper")
+    }
+
+    @Test
+    fun `should extract uses clause entries as dependencies`() {
+        // Given
+        val code = """
+            unit MyApp.Main;
+            interface
+            uses
+              System.SysUtils,
+              System.Classes;
+            type
+              TMain = class
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val dependencies = report.nodes.first().dependencies
+        assertThat(dependencies).contains(
+            Dependency(Path.fromStringWithDots("System.SysUtils")),
+            Dependency(Path.fromStringWithDots("System.Classes")),
+        )
+    }
+
+    @Test
+    fun `should add implicit wildcard dependency for own unit package`() {
+        // Given
+        val code = """
+            unit MyApp.Services;
+            interface
+            type
+              TService = class
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val dependencies = report.nodes.first().dependencies
+        assertThat(dependencies).contains(
+            Dependency(Path.fromStringWithDots("MyApp.Services"), true),
+        )
+    }
+
+    @Test
+    fun `should create node for each class in a given file`() {
+        // Given
+        val code = """
+            unit MyApp.Multiple;
+            interface
+            type
+              TFirst = class
+              end;
+              TSecond = class
+              end;
+              TThird = class
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val nodes = report.nodes
+        assertEquals(3, nodes.size)
+        val names = nodes.map { it.pathWithName.parts.last() }
+        assertThat(names).containsExactly("TFirst", "TSecond", "TThird")
+        nodes.forEach {
+            assertThat(it.pathWithName.parts.dropLast(1)).containsExactly("MyApp", "Multiple")
+        }
+    }
+
+    @Test
+    fun `should extract class, interface, record, and enum declaration types`() {
+        // Given
+        val code = """
+            unit MyApp.Types;
+            interface
+            type
+              TMyClass = class
+              end;
+              IMyInterface = interface
+              end;
+              TMyRecord = record
+              end;
+              TMyEnum = (meFirst, meSecond);
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val names = report.nodes.map { it.pathWithName.parts.last() }
+        assertThat(names).contains("TMyClass", "IMyInterface", "TMyRecord", "TMyEnum")
+    }
+
+    @Test
+    fun `should extract inheritance types`() {
+        // Given
+        val code = """
+            unit MyApp.Derived;
+            interface
+            type
+              TDerived = class(TBase)
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val usedTypes = report.nodes.first().usedTypes
+        assertThat(usedTypes).anyMatch { it.name == "TBase" }
+    }
+
+    @Test
+    fun `should extract field types`() {
+        // Given
+        val code = """
+            unit MyApp.Entity;
+            interface
+            type
+              TEntity = class
+                FName: TName;
+                FCount: TCounter;
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val usedTypes = report.nodes.first().usedTypes
+        assertThat(usedTypes).anyMatch { it.name == "TName" }
+        assertThat(usedTypes).anyMatch { it.name == "TCounter" }
+    }
+
+    @Test
+    fun `should extract types of generics correctly`() {
+        // Given
+        val code = """
+            unit MyApp.Generics;
+            interface
+            type
+              TContainer = class
+                FItems: TList<TItem>;
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val usedTypes = report.nodes.first().usedTypes
+        assertThat(usedTypes).contains(
+            Type.generic("TList", listOf(Type.simple("TItem")))
+        )
+    }
+
+    @Test
+    fun `should extract method parameter and return types`() {
+        // Given
+        val code = """
+            unit MyApp.Service;
+            interface
+            type
+              TService = class
+                function GetName(AId: TId): TName;
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val usedTypes = report.nodes.first().usedTypes
+        assertThat(usedTypes).anyMatch { it.name == "TId" }
+        assertThat(usedTypes).anyMatch { it.name == "TName" }
+    }
+
+    @Test
+    fun `should include parent class chain in nested type path`() {
+        // Given
+        val code = """
+            unit MyApp.Nested;
+            interface
+            type
+              TOuter = class
+              public
+                type
+                  TInner = class
+                  end;
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val innerNode = report.nodes.first { it.pathWithName.parts.last() == "TInner" }
+        assertThat(innerNode.pathWithName.parts).containsExactly("MyApp", "Nested", "TOuter", "TInner")
+    }
+
+    @Test
+    fun `should return empty report for empty file`() {
+        // Given
+        val code = """
+            unit MyApp.Empty;
+            interface
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        assertThat(report.nodes).isEmpty()
+    }
+
+    @Test
+    fun `should extract constructor calls to usedTypes correctly`() {
+        // Given
+        val code = """
+            unit MyApp.Service;
+            interface
+            type
+              TService = class
+                procedure DoWork;
+              end;
+            implementation
+            procedure TService.DoWork;
+            begin
+              THelper.Create;
+            end;
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val usedTypes = report.nodes.first().usedTypes
+        assertThat(usedTypes).anyMatch { it.name == "THelper" }
+    }
+
+    @Test
+    fun `should not add empty-path wildcard dependency for package-less file`() {
+        // Given
+        val code = """
+            type
+              TStandalone = class
+              end;
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val dependencies = report.nodes.flatMap { it.dependencies }
+        assertThat(dependencies).noneMatch { it.path.parts.isEmpty() }
+    }
+
+    @Test
+    fun `should set correct language and physical path for nodes`() {
+        // Given
+        val code = """
+            unit MyApp.Path;
+            interface
+            type
+              TPathUser = class
+              end;
+            implementation
+            end.
+        """.trimIndent()
+
+        // When
+        val report = analyze(code)
+
+        // Then
+        val node = report.nodes.first()
+        assertEquals(SupportedLanguage.DELPHI, node.language)
+        assertEquals("./path", node.physicalPath)
+    }
+}

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.dependacharta.pipeline.analysis.analyzers
 
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.cpp.CppAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.csharp.CSharpAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.delphi.DelphiAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.golang.GoAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.java.JavaAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.javascript.JavascriptAnalyzer
@@ -72,6 +73,11 @@ class LanguageAnalyzerFactoryTest {
                 physicalPath = "",
                 content = ""
             )
+            val delphiFileInfo = FileInfo(
+                language = SupportedLanguage.DELPHI,
+                physicalPath = "",
+                content = ""
+            )
             return listOf(
                 Arguments.of(javaFileInfo, JavaAnalyzer(javaFileInfo)),
                 Arguments.of(cSharpFileInfo, CSharpAnalyzer(cSharpFileInfo)),
@@ -82,7 +88,8 @@ class LanguageAnalyzerFactoryTest {
                 Arguments.of(goFileInfo, GoAnalyzer(goFileInfo)),
                 Arguments.of(pythonFileInfo, PythonAnalyzer(pythonFileInfo)),
                 Arguments.of(cppFileInfo, CppAnalyzer(cppFileInfo)),
-                Arguments.of(vueFileInfo, VueAnalyzer(vueFileInfo))
+                Arguments.of(vueFileInfo, VueAnalyzer(vueFileInfo)),
+                Arguments.of(delphiFileInfo, DelphiAnalyzer(delphiFileInfo))
             )
         }
     }

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguageTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguageTest.kt
@@ -61,6 +61,9 @@ class SupportedLanguageTest {
         assertThat(helpText).contains(".tsx")
         assertThat(helpText).contains("C#")
         assertThat(helpText).contains(".cs")
+        assertThat(helpText).contains("Delphi")
+        assertThat(helpText).contains(".pas")
+        assertThat(helpText).contains(".dpr")
     }
 
     @Test

--- a/delphi-edge-cases.md
+++ b/delphi-edge-cases.md
@@ -1,0 +1,30 @@
+# Delphi Edge Cases — DependaCharta
+
+Known issues in DC's Delphi support, discovered via Spring4D analysis (408 files, 1925 declarations).
+
+---
+
+## 1. RECORD declarations mapped to CLASS — **Low Priority**
+
+**File:** `analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/TseMappings.kt`
+
+```kotlin
+// Current
+DeclarationType.CLASS, DeclarationType.RECORD -> NodeType.CLASS
+
+// After fix
+DeclarationType.CLASS -> NodeType.CLASS
+DeclarationType.RECORD -> NodeType.RECORD   // or NodeType.VALUECLASS
+```
+
+TSE correctly identifies Delphi records as `DeclarationType.RECORD`. DC's `TseMappings` downgrades them to `NodeType.CLASS` because `NodeType` has no RECORD entry.
+
+**Impact:** Zero visual impact — the visualization does not use `nodeType` for rendering (all leaf nodes look identical). The field is metadata only in the `.cg.json` output.
+
+**Spring4D:** 1493 CLASS entries, 0 RECORD entries despite Spring4D containing records such as `TBitmapFileHeader`, `TItem<TKey>`, `THashEntry`.
+
+**Fix options:**
+- Add `RECORD` to `NodeType.kt` and map `DeclarationType.RECORD -> NodeType.RECORD`
+- Or map to the existing `VALUECLASS` (semantically closer — Delphi records are value types like C# structs)
+
+Check how `VALUECLASS` is currently used (C# structs) before deciding which to prefer.

--- a/plans/2026-04-24-add-delphi-support.md
+++ b/plans/2026-04-24-add-delphi-support.md
@@ -1,0 +1,77 @@
+---
+name: Add Delphi Support
+issue: ~
+state: complete
+version: ~
+---
+
+## Goal
+
+Add Delphi dependency analysis to DependaCharta by integrating the TSE `Language.DELPHI` support already implemented in TreeSitterLibrary. Follows the same migration pattern as Java/Kotlin/C#.
+
+## Tasks
+
+### 1. Extend `SupportedLanguage` enum
+
+Add a `DELPHI` entry to `analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguage.kt`:
+
+```kotlin
+DELPHI("Delphi", listOf("pas", "dpr")),
+```
+
+`SupportedLanguage.DELPHI.name = "DELPHI"` maps directly to `Language.DELPHI` in TSE via `Language.valueOf(language.name)` in `BaseLanguageAnalyzer`.
+
+### 2. Create `DelphiAnalyzer`
+
+Create `analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/delphi/DelphiAnalyzer.kt`.
+
+Identical pattern to `JavaAnalyzer` — extend `BaseLanguageAnalyzer`, no custom path building needed (Delphi uses the Class 1 namespace model: single `unit` name as package, top-level declarations only):
+
+```kotlin
+class DelphiAnalyzer(fileInfo: FileInfo) : BaseLanguageAnalyzer(fileInfo) {
+    override val language = SupportedLanguage.DELPHI
+}
+```
+
+### 3. Register in `LanguageAnalyzerFactory`
+
+Add to the `when` expression in `LanguageAnalyzerFactory.kt`:
+
+```kotlin
+SupportedLanguage.DELPHI -> DelphiAnalyzer(fileInfo)
+```
+
+### 4. Write `DelphiAnalyzerTest`
+
+Create `analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/DelphiAnalyzerTest.kt`.
+
+Cover Delphi-specific patterns (Given/When/Then structure):
+- Unit name extracted as package path (dotted: `unit MyCo.Utils` → `["MyCo", "Utils"]`)
+- `uses` clause entries extracted as dependencies
+- Implicit wildcard dependency for own unit package
+- Class, interface, record, enum declaration types
+- Inheritance types extracted
+- Field types extracted
+- Method parameter and return types extracted
+- Empty file / no declarations → empty report
+
+### 5. Update documentation
+
+- `DependaCharta/CLAUDE.md`: add Delphi to the "Supported Languages" list
+- `DependaCharta/CHANGELOG.md`: add entry under `[Unreleased]` / `Added`
+
+## Steps
+
+- [x] Add `DELPHI` to `SupportedLanguage.kt`
+- [x] Create `DelphiAnalyzer.kt`
+- [x] Register `DelphiAnalyzer` in `LanguageAnalyzerFactory.kt`
+- [x] Write `DelphiAnalyzerTest.kt`
+- [x] Run `mise run test-analysis` — all tests green
+- [x] Update `CLAUDE.md` supported languages list
+- [x] Update `CHANGELOG.md`
+
+## Notes
+
+- No visualization changes needed — visualization is language-agnostic.
+- No dc-compare verification needed — Delphi is a new language in DC, not a legacy migration.
+- TSE's `DelphiDependencyMapping` handles: unit/program package paths, `uses` clause imports (no wildcards in Delphi), class/interface/record/enum declarations, and 7 used-type categories (inheritance, params, returns, fields, variables, constructors, method calls).


### PR DESCRIPTION
Integrate Delphi dependency analysis via TSE Language.DELPHI, following the same pattern as Java/Kotlin/C#. Upgrades TSE to v0.7.0 (JitPack) which is the first release with Delphi support.