### PR TITLE
feat(analysis): add Rust dependency analysis support

### DIFF
--- a/.agents/skills/dependacharta/SKILL.md
+++ b/.agents/skills/dependacharta/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze codebase dependencies using DependaCharta. Detects dependen
 
 # DependaCharta Analysis
 
-Analyze source code dependencies without compilation using Tree-sitter parsers. Supports Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, and Vue.
+Analyze source code dependencies without compilation using Tree-sitter parsers. Supports Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi, and Rust.
 
 ## Setup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Rust dependency analysis support (`.rs` files), including Cargo-workspace crate-aware node paths (cross-crate `use other_crate::Type` references resolve) and `pub use` re-export flattening (a consumer's `use crate::Type` resolves through the crate's `lib.rs` re-export to the real `crate::module::Type` definition).
+
 ### Fixed
 
 - Restore import alias resolution for TypeScript/JavaScript/Vue (tsconfig/jsconfig `paths`, bundler aliases, Module Federation remotes), which was silently lost during the TreeSitterExcavationSite migration. Aliased imports now resolve to their target modules instead of being dropped from the dependency graph.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ For a detailed explanation of DependaCharta's domain concepts, see our [Domain M
 ### Key Technologies
 - **Analysis**: Kotlin, Tree-sitter, Gradle, Clikt CLI framework
 - **Visualization**: Angular 20, TypeScript, Cytoscape.js, Electron
-- **Supported Languages**: Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi
+- **Supported Languages**: Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi, Rust
 
 ### Project Structure
 ```
@@ -121,7 +121,7 @@ visualization/
 ### Important Patterns
 - Language analyzers live in `analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/<lang>/`
 - Each analyzer implements `LanguageAnalyzer` and extracts packages, imports, declarations, and used types from AST
-- **Java, Kotlin, and C#** delegate to the [TreeSitterExcavationSite](https://github.com/MaibornWolff/TreeSitterExcavationSite) (TSE) library via `TreeSitterDependencies.analyze()` and map TSE domain types to DC domain types. This is the target pattern for future language migrations.
+- **Java, Kotlin, C#, C++, TypeScript, JavaScript, Delphi, and Rust** delegate to the [TreeSitterExcavationSite](https://github.com/MaibornWolff/TreeSitterExcavationSite) (TSE) library via `TreeSitterDependencies.analyze()` and map TSE domain types to DC domain types. This is the target pattern for future language migrations. (Rust is TSE-native — it has no DC legacy analyzer.)
 - **Other languages** still use custom TreeSitter queries (TSQuery) directly. These can be migrated to TSE once it supports dependency analysis for the respective language.
 - Angular components follow standard Angular patterns with services for data management
 - Visualization uses reactive patterns with RxJS for state management

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The Analysis component is a command-line tool that analyzes codebases using [Tre
 - Dependencies between files and packages
 - Cycle detection with detailed cycle information
 - Levelization for architectural insights
-- Support for multiple programming languages: **Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi**
+- Support for multiple programming languages: **Java, C#, C++, TypeScript, JavaScript, PHP, Go, Python, Kotlin, Vue, Delphi, Rust**
 
 Don't see your language? You can [extend the supported languages](analysis/howto-add-new-language.md) by adding a new parser!
 

--- a/analysis/build.gradle.kts
+++ b/analysis/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.9.1")
+    implementation("com.github.MaibornWolff:TreeSitterExcavationSite:v0.11.0")
     implementation("io.github.bonede:tree-sitter:0.26.3")
     implementation("io.github.bonede:tree-sitter-typescript:0.23.2")
     implementation("io.github.bonede:tree-sitter-php:0.23.11")

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactory.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactory.kt
@@ -9,6 +9,7 @@ import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.javascript.Java
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.kotlin.KotlinAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.php.PhpAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.python.PythonAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.rust.RustAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.typescript.TypescriptAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.vue.VueAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
@@ -29,6 +30,7 @@ class LanguageAnalyzerFactory {
                 SupportedLanguage.KOTLIN -> KotlinAnalyzer(fileInfo)
                 SupportedLanguage.VUE -> VueAnalyzer(fileInfo)
                 SupportedLanguage.DELPHI -> DelphiAnalyzer(fileInfo)
+                SupportedLanguage.RUST -> RustAnalyzer(fileInfo)
             }
     }
 }

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/rust/RustAnalyzer.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/rust/RustAnalyzer.kt
@@ -1,0 +1,221 @@
+package de.maibornwolff.dependacharta.pipeline.analysis.analyzers.rust
+
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.LanguageAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.toNodeType
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.toType
+import de.maibornwolff.dependacharta.pipeline.analysis.common.splitNameToParts
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Dependency
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileReport
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Node
+import de.maibornwolff.dependacharta.pipeline.analysis.model.NodeType
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Path
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Type
+import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
+import de.maibornwolff.treesitter.excavationsite.api.Declaration
+import de.maibornwolff.treesitter.excavationsite.api.ImportDeclaration
+import de.maibornwolff.treesitter.excavationsite.api.ImportKind
+import de.maibornwolff.treesitter.excavationsite.api.Language
+import de.maibornwolff.treesitter.excavationsite.api.TreeSitterDependencies
+import de.maibornwolff.treesitter.excavationsite.api.UsedType
+
+/**
+ * Class-2 (multi-namespace) analyzer for Rust, modeled on [csharp.CSharpAnalyzer] but with a
+ * Rust-specific twist: a `.rs` file's module path from the crate root is filesystem-derived (not
+ * visible in the source TSE sees), so it is reconstructed here from [FileInfo.physicalPath] and
+ * prepended to TSE's in-file inline-`mod` chain ([Declaration.parentPath]).
+ *
+ * Imports keep TSE's verbatim leading `crate`/`self`/`super` segments; those are normalized here
+ * against the file module path. `namespacePrefix` on qualified inline used types yields a synthetic
+ * wildcard dependency per [cpp.CppAnalyzer].
+ *
+ * `pub use module::Type` re-exports (tagged [ImportKind.REEXPORT] by TSE) become [NodeType.REEXPORT]
+ * carrier nodes `crate::Type` → `crate::module::Type`: a crate flattens its public API at `lib.rs`, so
+ * consumers import the short `crate::Type` path. The resolver
+ * ([processing.dependencies.DependencyResolverService]) folds each carrier into an alias on the real
+ * definition node and drops the carrier, so a consumer's `crate::Type` reference resolves straight to
+ * `crate::module::Type`.
+ */
+class RustAnalyzer(
+    private val fileInfo: FileInfo,
+) : LanguageAnalyzer {
+    override fun analyze(): FileReport {
+        val result = TreeSitterDependencies.analyze(fileInfo.content, Language.RUST)
+        val crateRoot = deriveCrateRoot(fileInfo.physicalPath)
+        val fileModulePath = crateRoot + deriveInCrateModulePath(fileInfo.physicalPath)
+
+        val (reexportImports, regularImports) = result.imports.partition { it.kind == ImportKind.REEXPORT }
+        val imports = regularImports.map {
+            Dependency(path = Path(normalizePath(it.path, fileModulePath, crateRoot)), isWildcard = it.isWildcard)
+        }
+
+        val declarationNodes = result.declarations.map { declaration ->
+            toNode(declaration, imports, fileModulePath, crateRoot)
+        }
+        val reexportNodes = reexportImports.mapNotNull { toReexportNode(it, fileModulePath, crateRoot) }
+        return FileReport(declarationNodes + reexportNodes)
+    }
+
+    /**
+     * A `pub use module::Type` becomes a forwarding node at `crate::Type` (the path consumers use)
+     * that depends on the real definition `crate::module::Type`. Glob re-exports (`pub use foo::*`)
+     * are skipped — expanding them needs the re-exported module's contents (cross-file).
+     */
+    private fun toReexportNode(
+        import: ImportDeclaration,
+        fileModulePath: List<String>,
+        crateRoot: List<String>,
+    ): Node? {
+        if (import.isWildcard) return null
+        val name = import.bindingName ?: import.path.lastOrNull() ?: return null
+        val target = reexportTarget(import.path, fileModulePath, crateRoot)
+        if (target.isEmpty()) return null
+        return Node(
+            pathWithName = Path(fileModulePath + name),
+            physicalPath = fileInfo.physicalPath,
+            nodeType = NodeType.REEXPORT,
+            language = SupportedLanguage.RUST,
+            dependencies = setOf(Dependency(path = Path(target))),
+            usedTypes = setOf(Type.simple(name)),
+        )
+    }
+
+    /**
+     * The crate-rooted path a re-export points at. `crate`/`self`/`super` are normalized as usual;
+     * a bare leading segment is a crate-local module (the idiomatic `lib.rs` case, e.g.
+     * `pub use workshop::Workshop` in crate `domain` → `domain::workshop::Workshop`).
+     */
+    private fun reexportTarget(
+        path: List<String>,
+        fileModulePath: List<String>,
+        crateRoot: List<String>,
+    ): List<String> {
+        if (path.isEmpty()) return emptyList()
+        return when (path.first()) {
+            CRATE, SELF, SUPER -> normalizePath(path, fileModulePath, crateRoot)
+            else -> crateRoot + path
+        }
+    }
+
+    private fun toNode(
+        declaration: Declaration,
+        imports: List<Dependency>,
+        fileModulePath: List<String>,
+        crateRoot: List<String>,
+    ): Node {
+        val nodePath = fileModulePath + declaration.parentPath
+        return Node(
+            pathWithName = Path(nodePath + declaration.name),
+            physicalPath = fileInfo.physicalPath,
+            nodeType = declaration.type.toNodeType(),
+            language = SupportedLanguage.RUST,
+            dependencies = buildDependencies(declaration, imports, fileModulePath, crateRoot, nodePath),
+            usedTypes = declaration.usedTypes.map { it.toType() }.toSet(),
+        )
+    }
+
+    private fun buildDependencies(
+        declaration: Declaration,
+        imports: List<Dependency>,
+        fileModulePath: List<String>,
+        crateRoot: List<String>,
+        nodePath: List<String>,
+    ): Set<Dependency> {
+        val selfWildcard = Dependency.asWildcard(nodePath)
+        val namespacePrefixWildcards = declaration.usedTypes
+            .flatMap { it.collectNamespacePrefixes() }
+            .map { Dependency.asWildcard(normalizePath(it, fileModulePath, crateRoot)) }
+        return (imports + selfWildcard + namespacePrefixWildcards).toSet()
+    }
+
+    private fun UsedType.collectNamespacePrefixes(): List<List<String>> {
+        val own = if (namespacePrefix.isEmpty()) emptyList() else listOf(namespacePrefix)
+        return own + genericTypes.flatMap { it.collectNamespacePrefixes() }
+    }
+
+    /**
+     * Resolves a path's leading `crate`/`self`/`super` segments against the file's module path:
+     * `crate` → the crate root (the crate-name prefix), `self` → the file module, each `super`
+     * strips one trailing segment. Paths starting with another crate name (`domain::…`,
+     * cross-crate) or a `use`-bound name are left untouched — they are already crate-rooted, which
+     * is exactly why node paths must also carry the crate name (see [deriveCrateRoot]) so the two
+     * sides match during resolution.
+     */
+    private fun normalizePath(
+        path: List<String>,
+        fileModulePath: List<String>,
+        crateRoot: List<String>
+    ): List<String> {
+        if (path.isEmpty()) return path
+        return when (path.first()) {
+            CRATE -> crateRoot + path.drop(1)
+            SELF -> fileModulePath + path.drop(1)
+            SUPER -> normalizeSuperPath(path, fileModulePath)
+            else -> path
+        }
+    }
+
+    private fun normalizeSuperPath(
+        path: List<String>,
+        fileModulePath: List<String>
+    ): List<String> {
+        var base = fileModulePath
+        var index = 0
+        while (index < path.size && path[index] == SUPER) {
+            base = base.dropLast(1)
+            index++
+        }
+        return base + path.drop(index)
+    }
+
+    /**
+     * The crate-name prefix for node paths: the directory immediately before the last `src`
+     * (`.../crates/domain/src/workshop.rs` → `[domain]`). Empty when there is no enclosing crate
+     * directory (e.g. a bare `src/lib.rs` in tests, or a loose file). Including the crate name is
+     * what lets cross-crate imports (`use domain::workshop::Workshop`) resolve to the right node,
+     * since a Rust path is always rooted at a crate.
+     */
+    private fun deriveCrateRoot(physicalPath: String): List<String> {
+        val parts = splitNameToParts(physicalPath).filter { it != CURRENT_DIR }
+        val srcIndex = parts.lastIndexOf(SRC_DIR)
+        return if (srcIndex > 0) listOf(parts[srcIndex - 1]) else emptyList()
+    }
+
+    /**
+     * The in-crate module path from a physical path using Rust 2018 rules: taken relative to the
+     * last `src` directory. `mod.rs` is a directory-module marker at any depth (`src/foo/mod.rs` →
+     * `[foo]`); `lib.rs`/`main.rs` are crate roots only at the crate root (`src/lib.rs` → `[]`) and
+     * otherwise behave like any file (`src/foo/lib.rs` → `[foo, lib]`); every other file becomes the
+     * final module segment (`src/foo/bar.rs` → `[foo, bar]`). The crate name is added separately by
+     * [deriveCrateRoot].
+     */
+    private fun deriveInCrateModulePath(physicalPath: String): List<String> {
+        val parts = splitNameToParts(physicalPath).filter { it != CURRENT_DIR }
+        val relativeParts = stripToCrateRoot(parts)
+        if (relativeParts.isEmpty()) return emptyList()
+
+        val fileName = relativeParts.last()
+        val directories = relativeParts.dropLast(1)
+        return when {
+            fileName == MOD_FILE -> directories
+            fileName in CRATE_ROOT_FILES && directories.isEmpty() -> emptyList()
+            else -> directories + fileName.removeSuffix(RUST_EXTENSION)
+        }
+    }
+
+    private fun stripToCrateRoot(parts: List<String>): List<String> {
+        val srcIndex = parts.lastIndexOf(SRC_DIR)
+        return if (srcIndex in 0 until parts.lastIndex) parts.drop(srcIndex + 1) else parts
+    }
+
+    companion object {
+        private const val CRATE = "crate"
+        private const val SELF = "self"
+        private const val SUPER = "super"
+        private const val SRC_DIR = "src"
+        private const val CURRENT_DIR = "."
+        private const val RUST_EXTENSION = ".rs"
+        private const val MOD_FILE = "mod.rs"
+        private val CRATE_ROOT_FILES = setOf("lib.rs", "main.rs")
+    }
+}

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverService.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/processing/dependencies/DependencyResolverService.kt
@@ -2,6 +2,7 @@ package de.maibornwolff.dependacharta.pipeline.processing.dependencies
 
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileReport
 import de.maibornwolff.dependacharta.pipeline.analysis.model.Node
+import de.maibornwolff.dependacharta.pipeline.analysis.model.NodeType
 import de.maibornwolff.dependacharta.pipeline.processing.cycledetection.model.NodeInformation
 import de.maibornwolff.dependacharta.pipeline.processing.dependencies.dictionaries.*
 import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
@@ -9,10 +10,30 @@ import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
 class DependencyResolverService {
     companion object {
         fun resolveNodes(fileReports: Collection<FileReport>): Collection<Node> {
-            val nodes = fileReports.flatMap { it.nodes }
+            val nodes = applyRustReexportAliases(fileReports.flatMap { it.nodes })
             val dictionary = getDictionary(nodes)
             val knownNodePaths = getKnownNodePaths(nodes)
             return nodes.map { it.resolveTypes(dictionary, standardLibraryFor(it.language).get(), knownNodePaths) }
+        }
+
+        /**
+         * Folds Rust `pub use` re-export forwarding nodes into aliases on their real definition node,
+         * then drops the forwarding nodes. A consumer importing the flattened `crate::Type` path then
+         * resolves straight to `crate::module::Type` via the alias — instead of through a same-named
+         * forwarding node, which would otherwise capture the definition's own self-references and
+         * fabricate `crate::Type ↔ crate::module::Type` cycles.
+         */
+        private fun applyRustReexportAliases(nodes: List<Node>): List<Node> {
+            val (reexports, rest) = nodes.partition {
+                it.language == SupportedLanguage.RUST && it.nodeType == NodeType.REEXPORT
+            }
+            if (reexports.isEmpty()) return nodes
+            val byPath = rest.associateBy { it.pathWithName.withDots() }
+            reexports.forEach { reexport ->
+                val target = reexport.dependencies.firstOrNull { !it.isWildcard }?.path ?: return@forEach
+                byPath[target.withDots()]?.pathWithName?.withAlias(reexport.pathWithName)
+            }
+            return rest
         }
 
         fun mapNodeInfo(node: Node) =
@@ -40,6 +61,7 @@ class DependencyResolverService {
                 SupportedLanguage.KOTLIN -> KotlinStandardLibrary()
                 SupportedLanguage.VUE -> EmptyStandardLibrary()
                 SupportedLanguage.DELPHI -> EmptyStandardLibrary()
+                SupportedLanguage.RUST -> EmptyStandardLibrary()
             }
     }
 }

--- a/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguage.kt
+++ b/analysis/src/main/kotlin/de/maibornwolff/dependacharta/pipeline/shared/SupportedLanguage.kt
@@ -15,6 +15,7 @@ enum class SupportedLanguage(
     KOTLIN("Kotlin", listOf("kt", "kts")),
     VUE("Vue", listOf("vue")),
     DELPHI("Delphi", listOf("pas", "dpr")),
+    RUST("Rust", listOf("rs")),
 }
 
 fun languagesByExtension(languages: List<SupportedLanguage>) =

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/LanguageAnalyzerFactoryTest.kt
@@ -9,6 +9,7 @@ import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.javascript.Java
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.kotlin.KotlinAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.php.PhpAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.python.PythonAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.rust.RustAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.typescript.TypescriptAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.vue.VueAnalyzer
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
@@ -78,6 +79,11 @@ class LanguageAnalyzerFactoryTest {
                 physicalPath = "",
                 content = ""
             )
+            val rustFileInfo = FileInfo(
+                language = SupportedLanguage.RUST,
+                physicalPath = "",
+                content = ""
+            )
             return listOf(
                 Arguments.of(javaFileInfo, JavaAnalyzer(javaFileInfo)),
                 Arguments.of(cSharpFileInfo, CSharpAnalyzer(cSharpFileInfo)),
@@ -89,7 +95,8 @@ class LanguageAnalyzerFactoryTest {
                 Arguments.of(pythonFileInfo, PythonAnalyzer(pythonFileInfo)),
                 Arguments.of(cppFileInfo, CppAnalyzer(cppFileInfo)),
                 Arguments.of(vueFileInfo, VueAnalyzer(vueFileInfo)),
-                Arguments.of(delphiFileInfo, DelphiAnalyzer(delphiFileInfo))
+                Arguments.of(delphiFileInfo, DelphiAnalyzer(delphiFileInfo)),
+                Arguments.of(rustFileInfo, RustAnalyzer(rustFileInfo))
             )
         }
     }

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/RustAnalyzerTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/RustAnalyzerTest.kt
@@ -4,6 +4,7 @@ import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.rust.RustAnalyz
 import de.maibornwolff.dependacharta.pipeline.analysis.model.Dependency
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
 import de.maibornwolff.dependacharta.pipeline.analysis.model.FileReport
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Node
 import de.maibornwolff.dependacharta.pipeline.analysis.model.NodeType
 import de.maibornwolff.dependacharta.pipeline.analysis.model.Path
 import de.maibornwolff.dependacharta.pipeline.analysis.model.Type
@@ -319,5 +320,139 @@ class RustAnalyzerTest {
         val render = resolved.first { it.pathWithName.parts.last() == "render" }
         assertThat(render.resolvedNodeDependencies.internalDependencies.map { it.path.withDots() })
             .contains("domain.workshop.Workshop")
+    }
+
+    @Test
+    fun `should resolve crate and self prefixes in pub use re-exports to the crate-rooted target`() {
+        // Given — a crate root re-exporting via both crate:: and self::
+        val code = """
+            pub use crate::workshop::Workshop;
+            pub use self::finding::Finding;
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/lib.rs")
+
+        // Then — both forms resolve to the crate-rooted definition path
+        assertThat(report.node("Workshop").dependencies).contains(Dependency(Path(listOf("domain", "workshop", "Workshop"))))
+        assertThat(report.node("Finding").dependencies).contains(Dependency(Path(listOf("domain", "finding", "Finding"))))
+    }
+
+    @Test
+    fun `should resolve a super prefix in a pub use re-export from a submodule`() {
+        // Given — a submodule re-exporting a sibling-of-parent item via super::
+        val code = "pub use super::shared::Helper;"
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/feature/mod.rs")
+
+        // Then — fileModulePath [domain, feature]; super:: strips one segment -> [domain, shared, Helper]
+        val helper = report.node("Helper")
+        assertThat(helper.nodeType).isEqualTo(NodeType.REEXPORT)
+        assertThat(helper.pathWithName.parts).containsExactly("domain", "feature", "Helper")
+        assertThat(helper.dependencies).contains(Dependency(Path(listOf("domain", "shared", "Helper"))))
+    }
+
+    @Test
+    fun `should not emit a node for a glob pub use re-export`() {
+        // Given — a wildcard re-export (needs cross-file expansion; out of scope)
+        val code = "pub use internal::*;"
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/lib.rs")
+
+        // Then — no forwarding node is synthesized for a glob re-export
+        assertThat(report.nodes).isEmpty()
+    }
+
+    @Test
+    fun `should normalize chained super segments in imports`() {
+        // Given — a deep module importing via super::super::
+        val code = """
+            use super::super::shared::Helper;
+            struct Foo { h: Helper }
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/a/b.rs")
+
+        // Then — fileModulePath [domain, a, b]; two supers strip two segments -> [domain, shared, Helper]
+        assertThat(report.node("Foo").dependencies).contains(Dependency(Path(listOf("domain", "shared", "Helper"))))
+    }
+
+    @Test
+    fun `should derive the module path for a file outside any src directory`() {
+        // Given — a build script with no enclosing src/ directory
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "build.rs")
+
+        // Then — falls back to the file name as the module segment, with no crate prefix
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("build", "Foo")
+    }
+
+    @Test
+    fun `should derive an empty module path for a blank physical path`() {
+        // Given — no physical path information at all
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "")
+
+        // Then — the node sits at the (empty) crate root
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("Foo")
+    }
+
+    @Test
+    fun `should ignore current-directory segments in the physical path`() {
+        // Given — a path with a leading ./ segment
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "./crates/domain/src/model.rs")
+
+        // Then — the "." segment is dropped; crate name and module are derived normally
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("domain", "model", "Foo")
+    }
+
+    @Test
+    fun `should drop a re-export carrier that has no concrete target`() {
+        // Given — a synthetic RUST re-export node whose only dependency is a wildcard (no concrete target)
+        val carrier = Node(
+            pathWithName = Path(listOf("domain", "Foo")),
+            physicalPath = "x",
+            nodeType = NodeType.REEXPORT,
+            language = SupportedLanguage.RUST,
+            dependencies = setOf(Dependency.asWildcard(listOf("domain"))),
+            usedTypes = emptySet()
+        )
+
+        // When
+        val resolved = DependencyResolverService.resolveNodes(listOf(FileReport(listOf(carrier))))
+
+        // Then — with no concrete target to alias onto, the carrier is dropped without error
+        assertThat(resolved.map { it.pathWithName.withDots() }).doesNotContain("domain.Foo")
+    }
+
+    @Test
+    fun `should drop a re-export whose target is not in the analyzed set`() {
+        // Given — domain re-exports Workshop, but workshop.rs is NOT among the analyzed files
+        val domainLib = analyze("pub use workshop::Workshop;", "/repo/crates/domain/src/lib.rs")
+        val consumer = analyze(
+            """
+            use domain::Workshop;
+            pub fn render(w: &Workshop) -> String { String::new() }
+            """.trimIndent(),
+            "/repo/crates/adapter_exporter/src/markdown.rs"
+        )
+
+        // When
+        val resolved = DependencyResolverService.resolveNodes(listOf(domainLib, consumer))
+
+        // Then — with no real definition to alias onto, the carrier is dropped and render stays unresolved
+        assertThat(resolved.map { it.pathWithName.withDots() }).doesNotContain("domain.Workshop")
+        val render = resolved.first { it.pathWithName.parts.last() == "render" }
+        assertThat(render.resolvedNodeDependencies.internalDependencies).isEmpty()
     }
 }

--- a/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/RustAnalyzerTest.kt
+++ b/analysis/src/test/kotlin/de/maibornwolff/dependacharta/pipeline/analysis/analyzers/RustAnalyzerTest.kt
@@ -1,0 +1,323 @@
+package de.maibornwolff.dependacharta.pipeline.analysis.analyzers
+
+import de.maibornwolff.dependacharta.pipeline.analysis.analyzers.rust.RustAnalyzer
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Dependency
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileInfo
+import de.maibornwolff.dependacharta.pipeline.analysis.model.FileReport
+import de.maibornwolff.dependacharta.pipeline.analysis.model.NodeType
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Path
+import de.maibornwolff.dependacharta.pipeline.analysis.model.Type
+import de.maibornwolff.dependacharta.pipeline.processing.dependencies.DependencyResolverService
+import de.maibornwolff.dependacharta.pipeline.shared.SupportedLanguage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RustAnalyzerTest {
+    private fun analyze(
+        code: String,
+        physicalPath: String = "src/lib.rs"
+    ): FileReport = RustAnalyzer(FileInfo(SupportedLanguage.RUST, physicalPath, code)).analyze()
+
+    private fun FileReport.node(name: String) = nodes.first { it.pathWithName.parts.last() == name }
+
+    @Test
+    fun `should prefix node path with the file module derived from the physical path`() {
+        // Given
+        val code = "pub struct UserService {}"
+
+        // When
+        val report = analyze(code, "src/service/users.rs")
+
+        // Then
+        assertThat(report.node("UserService").pathWithName.parts).containsExactly("service", "users", "UserService")
+    }
+
+    @Test
+    fun `should treat lib rs as the crate root with an empty module path`() {
+        // Given
+        val code = "struct Root {}"
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.node("Root").pathWithName.parts).containsExactly("Root")
+    }
+
+    @Test
+    fun `should treat mod rs as the directory module at any depth`() {
+        // Given
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "src/feature/sub/mod.rs")
+
+        // Then
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("feature", "sub", "Foo")
+    }
+
+    @Test
+    fun `should treat a non-root lib rs as a regular file module`() {
+        // Given
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "src/feature/lib.rs")
+
+        // Then
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("feature", "lib", "Foo")
+    }
+
+    @Test
+    fun `should prefix the node path with the crate name in a workspace layout`() {
+        // Given
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "/home/dev/crates/core/src/domain/model.rs")
+
+        // Then — the crate dir before src ("core") is prepended so cross-crate imports can resolve
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("core", "domain", "model", "Foo")
+    }
+
+    @Test
+    fun `should resolve crate imports against the crate name so they match cross-crate references`() {
+        // Given — a file in crate "domain" that references a sibling module via crate::
+        val code = """
+            use crate::workshop::Workshop;
+            pub struct Service { w: Workshop }
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/service.rs")
+
+        // Then — the node carries the crate name, and crate:: resolves to [domain, ...] (not dropped),
+        // so it is byte-identical to how another crate would import it via use domain::workshop::Workshop
+        assertThat(report.node("Service").pathWithName.parts).containsExactly("domain", "service", "Service")
+        assertThat(report.node("Service").dependencies).contains(
+            Dependency(Path(listOf("domain", "workshop", "Workshop")))
+        )
+    }
+
+    @Test
+    fun `should append the inline module chain to the file module path`() {
+        // Given
+        val code = "mod inner { struct Foo {} }"
+
+        // When
+        val report = analyze(code, "src/feature.rs")
+
+        // Then
+        assertThat(report.node("Foo").pathWithName.parts).containsExactly("feature", "inner", "Foo")
+    }
+
+    @Test
+    fun `should map regular use imports including glob and alias to dependencies`() {
+        // Given — regular `use` imports (a `pub use` would be a forwarding node, not a dependency)
+        val code = """
+            use std::collections::HashMap;
+            use a::b::*;
+            use x::Y as Z;
+            struct Foo {}
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.node("Foo").dependencies).contains(
+            Dependency(Path(listOf("std", "collections", "HashMap"))),
+            Dependency(Path(listOf("a", "b")), isWildcard = true),
+            Dependency(Path(listOf("x", "Y"))),
+        )
+    }
+
+    @Test
+    fun `should normalize crate self and super import segments against the file module path`() {
+        // Given
+        val code = """
+            use crate::model::User;
+            use self::helper::Helper;
+            use super::sibling::Sibling;
+            struct Foo {}
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "src/a/b.rs")
+
+        // Then
+        assertThat(report.node("Foo").dependencies).contains(
+            Dependency(Path(listOf("model", "User"))),
+            Dependency(Path(listOf("a", "b", "helper", "Helper"))),
+            Dependency(Path(listOf("a", "sibling", "Sibling"))),
+        )
+    }
+
+    @Test
+    fun `should add an intra-module self wildcard dependency per declaration`() {
+        // Given
+        val code = "struct Foo {}"
+
+        // When
+        val report = analyze(code, "src/a/b.rs")
+
+        // Then
+        assertThat(report.node("Foo").dependencies).contains(Dependency.asWildcard(listOf("a", "b")))
+    }
+
+    @Test
+    fun `should map declaration kinds to node types`() {
+        // Given
+        val code = """
+            struct AStruct {}
+            enum AnEnum { V }
+            trait ATrait {}
+            fn a_fn() {}
+            type AnAlias = u32;
+            const A_CONST: u32 = 0;
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.node("AStruct").nodeType).isEqualTo(NodeType.CLASS)
+        assertThat(report.node("AnEnum").nodeType).isEqualTo(NodeType.ENUM)
+        assertThat(report.node("ATrait").nodeType).isEqualTo(NodeType.INTERFACE)
+        assertThat(report.node("a_fn").nodeType).isEqualTo(NodeType.FUNCTION)
+        assertThat(report.node("AnAlias").nodeType).isEqualTo(NodeType.CLASS)
+        assertThat(report.node("A_CONST").nodeType).isEqualTo(NodeType.VARIABLE)
+    }
+
+    @Test
+    fun `should fold impl trait for type into the target type as an inheritance used type`() {
+        // Given
+        val code = """
+            struct Foo {}
+            impl Display for Foo {
+                fn fmt(&self, f: Formatter) -> Result { todo!() }
+            }
+        """.trimIndent()
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.node("Foo").usedTypes).contains(Type.simple("Display"), Type.simple("Formatter"))
+    }
+
+    @Test
+    fun `should extract signature used types with nested generics`() {
+        // Given
+        val code = "struct Foo { bar: Bar, items: Vec<Item> }"
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.node("Foo").usedTypes).containsExactlyInAnyOrder(
+            Type.simple("Bar"),
+            Type.generic("Vec", listOf(Type.simple("Item"))),
+        )
+    }
+
+    @Test
+    fun `should emit a synthetic wildcard dependency for a qualified inline type`() {
+        // Given
+        val code = "struct S { f: crate::events::Event }"
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        val foo = report.node("S")
+        assertThat(foo.usedTypes).contains(Type.simple("Event"))
+        assertThat(foo.dependencies).contains(Dependency.asWildcard(listOf("events")))
+    }
+
+    @Test
+    fun `should produce an empty report for an empty file`() {
+        // Given
+        val code = ""
+
+        // When
+        val report = analyze(code, "src/lib.rs")
+
+        // Then
+        assertThat(report.nodes).isEmpty()
+    }
+
+    @Test
+    fun `should create a forwarding node for a pub use re-export`() {
+        // Given — a crate's lib.rs flattens its public API via pub use
+        val code = "pub use workshop::Workshop;"
+
+        // When
+        val report = analyze(code, "/repo/crates/domain/src/lib.rs")
+
+        // Then — a REEXPORT node domain.Workshop forwards to the real definition domain.workshop.Workshop
+        val node = report.node("Workshop")
+        assertThat(node.nodeType).isEqualTo(NodeType.REEXPORT)
+        assertThat(node.pathWithName.parts).containsExactly("domain", "Workshop")
+        assertThat(node.dependencies).contains(Dependency(Path(listOf("domain", "workshop", "Workshop"))))
+    }
+
+    @Test
+    fun `should resolve a consumer through a flattened pub use re-export without a cycle`() {
+        // Given — domain defines a self-referencing Workshop in a submodule and re-exports it from
+        // lib.rs; a consumer in another crate imports the flattened path `use domain::Workshop`
+        val workshopMod = analyze(
+            """
+            pub struct Workshop { id: String }
+            impl Workshop { pub fn clone_it(&self) -> Workshop { todo!() } }
+            """.trimIndent(),
+            "/repo/crates/domain/src/workshop.rs"
+        )
+        val domainLib = analyze("pub use workshop::Workshop;", "/repo/crates/domain/src/lib.rs")
+        val consumer = analyze(
+            """
+            use domain::Workshop;
+            pub fn render(w: &Workshop) -> String { String::new() }
+            """.trimIndent(),
+            "/repo/crates/adapter_exporter/src/markdown.rs"
+        )
+
+        // When
+        val resolved = DependencyResolverService.resolveNodes(listOf(workshopMod, domainLib, consumer))
+
+        // Then — the carrier node is folded into an alias and dropped; render resolves straight to the
+        // real definition, and the self-reference does NOT create a domain.Workshop ↔ definition cycle
+        assertThat(resolved.map { it.pathWithName.withDots() }).doesNotContain("domain.Workshop")
+        val render = resolved.first { it.pathWithName.parts.last() == "render" }
+        assertThat(render.resolvedNodeDependencies.internalDependencies.map { it.path.withDots() })
+            .containsExactly("domain.workshop.Workshop")
+        val workshop = resolved.first { it.pathWithName.withDots() == "domain.workshop.Workshop" }
+        assertThat(workshop.resolvedNodeDependencies.internalDependencies).isEmpty()
+    }
+
+    @Test
+    fun `should resolve a cross-crate dependency to an internal edge`() {
+        // Given — a type in crate "domain" used by a free function in crate "adapter" via use domain::...
+        val domain = RustAnalyzer(
+            FileInfo(SupportedLanguage.RUST, "/repo/crates/domain/src/workshop.rs", "pub struct Workshop { id: String }")
+        ).analyze()
+        val adapter = RustAnalyzer(
+            FileInfo(
+                SupportedLanguage.RUST,
+                "/repo/crates/adapter_exporter/src/markdown.rs",
+                """
+                use domain::workshop::Workshop;
+                pub fn render(workshop: &Workshop) -> String { String::new() }
+                """.trimIndent()
+            )
+        ).analyze()
+
+        // When — the cross-file resolver connects the graph
+        val resolved = DependencyResolverService.resolveNodes(listOf(domain, adapter))
+
+        // Then — render's signature use of Workshop becomes an INTERNAL edge to domain.workshop.Workshop
+        val render = resolved.first { it.pathWithName.parts.last() == "render" }
+        assertThat(render.resolvedNodeDependencies.internalDependencies.map { it.path.withDots() })
+            .contains("domain.workshop.Workshop")
+    }
+}

--- a/plans/tse-rust-integration.md
+++ b/plans/tse-rust-integration.md
@@ -1,0 +1,156 @@
+---
+name: tse-rust-integration
+issue:
+state: complete
+version: v0.11.0
+---
+
+## Goal
+
+Add **Rust** as a supported language in DependaCharta by consuming TSE's new Rust dependency analysis
+(`TreeSitterDependencies.analyze(content, Language.RUST)`). This is **PR 2 of 2** — it depends on the
+TSE Rust dependency support (PR 1: `TreeSitterExcavationSite/plans/add-rust-dependency-support.md`)
+being merged and **released as a tag**. Rust is brand-new to DC (no legacy analyzer), so this is a
+fresh language addition, not a migration — closest precedents: `plans/2026-04-24-add-delphi-support.md`
+(new language) and `plans/tse-typescript-javascript-integration.md` (composite-build workflow).
+
+Rust is a **Class-2 / multi-namespace language** (nested `mod` blocks), so `RustAnalyzer` follows
+`CSharpAnalyzer` (implements `LanguageAnalyzer` directly, derives per-declaration path from
+`parentPath`), **plus** a Rust-specific step C# doesn't need: derive the file's crate-root module path
+from `physicalPath` (modeled on Go's `GoPackageQuery.derivePackagePathFromFilePath`) and normalize
+`crate`/`self`/`super` in imports, because a `.rs` file's module path is filesystem-derived, not in its
+content.
+
+## Tasks
+
+### 1. Set up composite build for local iteration (revert before final PR)
+- TSE's Rust support won't be tagged while iterating. In `analysis/settings.gradle.kts` add
+  `includeBuild("../../TreeSitterExcavationSite")` with `dependencySubstitution` substituting
+  `com.github.MaibornWolff:TreeSitterExcavationSite` → the local project (precedent:
+  `plans/tse-typescript-javascript-integration.md`). Keep the JitPack repo for transitive deps.
+- This lets `RustAnalyzerTest` run against the in-progress local TSE extractors before any tag exists.
+- **Revert** `settings.gradle.kts` and pin the published tag (Task 7) before opening the final PR.
+
+### 2. Register the language (compile-breaker wiring)
+- `analysis/.../pipeline/shared/SupportedLanguage.kt`: add `RUST("Rust", listOf("rs")),`. The enum
+  name **must** be exactly `RUST` so `Language.valueOf(name)` resolves to TSE's `Language.RUST`.
+  `suffixes` is the single source of truth — extension detection (walker + `determineLanguage`) and
+  the help text adapt automatically; `RootDirectoryWalker`/`FileInfo` need no change.
+- `analysis/.../analyzers/LanguageAnalyzerFactory.kt`: add `SupportedLanguage.RUST -> RustAnalyzer(fileInfo)`
+  (+ import). Exhaustive `when`, no `else` → won't compile without it.
+- `analysis/.../processing/dependencies/DependencyResolverService.kt`: add
+  `SupportedLanguage.RUST -> EmptyStandardLibrary()` to `standardLibraryFor`. Second exhaustive `when`.
+  (Std/core/alloc are out-of-project externals; `EmptyStandardLibrary` is the right default — Rust
+  has no bundled stdlib dictionary in v1.)
+
+### 3. Implement RustAnalyzer (TDD, Class-2 like CSharpAnalyzer)
+- `analysis/.../analyzers/rust/RustAnalyzer.kt`, implementing `LanguageAnalyzer` (not
+  `BaseLanguageAnalyzer`, because of the file-module-path step). Per `result.declarations`:
+  - `fileModulePath = deriveModulePathFromPhysicalPath(fileInfo.physicalPath)` — crate root via
+    nearest `Cargo.toml`/`src`; `lib.rs`/`main.rs`/`mod.rs` → the dir module; `foo.rs` → `…::foo`
+    (Rust 2018 path rules). Model on Go's `GoPackageQuery.derivePackagePathFromFilePath`.
+  - `nodePath = fileModulePath + declaration.parentPath` (TSE's `parentPath` = in-file inline-`mod`
+    chain; `result.packagePath` is ignored, as in `CSharpAnalyzer`).
+  - imports: normalize leading segments against `fileModulePath` (`self`→fileModulePath,
+    `super`→drop last, `crate`→crate root), then `ImportDeclaration.toDependency()`.
+  - self-wildcard: `Dependency(Path(nodePath), isWildcard = true)` per declaration (intra-module
+    resolution).
+  - `namespacePrefix` on used types: emit a synthetic `Dependency(Path(prefix), isWildcard=true)` per
+    `UsedType` with a non-empty `namespacePrefix` (mirror `CppAnalyzer`; resolver consumes it via the
+    existing wildcard-prepend loop).
+  - Map `declaration.type.toNodeType()` and `usedTypes.map { it.toType() }` via the existing
+    `TseMappings.kt` — **no change there** (TSE reuses the existing `DeclarationType` values).
+- `analysis/src/test/.../analyzers/RustAnalyzerTest.kt` (pattern from `DelphiAnalyzerTest`, inline
+  source, Given/When/Then): module path as node prefix, `use` imports → deps incl. glob/alias/`pub use`,
+  `crate`/`self`/`super` normalization, intra-module self-wildcard, struct/enum/trait/fn/type-alias
+  node types, nested `mod` → `parentPath`, `impl Trait for Type` → inheritance edge, signature used
+  types (fields/params/returns/bounds/where/supertraits), qualified `namespacePrefix` synthetic dep,
+  empty file → empty report.
+
+### 4. Update the factory test
+- `analysis/src/test/.../analyzers/LanguageAnalyzerFactoryTest.kt`: add a `rustFileInfo` + an
+  `Arguments.of(rustFileInfo, RustAnalyzer(rustFileInfo))` row (+ import). The parameterized test
+  enumerates every language and must include Rust.
+
+### 5. Docs + changelog
+- Add "Rust" to the supported-languages lists: `README.md`, `CLAUDE.md` (Key Technologies +
+  Migrating-a-Language note), `.agents/skills/dependacharta/SKILL.md`.
+- `CHANGELOG.md` `[Unreleased]/Added`: "Add Rust dependency analysis support (.rs files)".
+- **Visualization: no change** — the Angular app is language-agnostic (`language` is a pass-through
+  string, never branched on). No legend/color/icon entry needed.
+
+### 6. Validate (no legacy analyzer → /dc-compare is N/A)
+- `mise run test-analysis` green (ktlint runs in the test task). `RustAnalyzerTest` is the primary
+  gate since there's no DC-main baseline to diff against.
+- Manual: `mise run analyze <a real Rust repo>` (e.g. a mid-size crate with nested modules, traits,
+  generics) and eyeball the `.cg.json` — sane nodes/edges, no empty-named nodes, externals
+  (`std`/`tokio`/…) classified out of project. Optionally add `exampleProjects/RustExample/`.
+
+### 7. Switch to the released TSE tag (final PR step)
+- After TSE PR 1 is tagged: revert the Task-1 composite build and bump
+  `analysis/build.gradle.kts:23` `com.github.MaibornWolff:TreeSitterExcavationSite:v0.9.1` → the new
+  tag (e.g. `v0.10.0`). This is the **only** place the TSE version is referenced.
+- Re-run `mise run test-analysis` green against the published artifact.
+
+## Steps
+
+- [x] Complete Task 1: composite build for local iteration
+- [x] Complete Task 2: register `RUST` in `SupportedLanguage`, `LanguageAnalyzerFactory`,
+  `DependencyResolverService` (3 compile-breaker spots)
+- [x] Complete Task 3: `RustAnalyzer` + `RustAnalyzerTest` (TDD, Class-2 + file-module-path)
+- [x] Complete Task 4: `LanguageAnalyzerFactoryTest` Rust row
+- [x] Complete Task 5: docs (README, CLAUDE.md, SKILL.md) + CHANGELOG
+- [x] Complete Task 6: `mise run test-analysis` green (614 tests, 0 fail; run on JDK 17) + manual
+  `analyze` on a multi-module crate — cross-file `crate::` imports resolved, impl-folded method
+  types produce real cross-module edges, externals (`std`/`Display`/…) classified out of project,
+  no empty-named nodes, correct module paths from physical paths.
+- [x] Complete Task 7: reverted the composite build in `settings.gradle.kts` and bumped
+  `build.gradle.kts` TSE dependency `v0.9.1` → **`v0.11.0`** (the released tag with Rust support +
+  `ImportKind.REEXPORT`). Full suite green against the published JitPack artifact (621 tests, 0
+  failures) and `./gradlew fatJar` packages cleanly again (the composite-build `beforeEvaluate`
+  quirk is gone).
+
+## Notes
+
+- **SHCBarber validation (real Tauri Cargo workspace, 10 crates / 140 src files) drove two
+  improvements beyond the original plan scope** (orphan-node double-check found both):
+  1. **Crate-aware node paths** — node paths now include the crate name (dir before `src`, via
+     `RustAnalyzer.deriveCrateRoot`), and `crate::` resolves to it. Without this, cross-crate
+     `use other_crate::Type` imports never matched the (crate-name-stripped) definition node, so
+     every cross-crate edge was silently dropped. This overrides the plan's accepted "no cross-crate
+     resolution" v1 limitation. Recovered ~340 cross-crate edges; ~1.6k after re-exports.
+  2. **`pub use` re-export flattening** — crates flatten their public API at `lib.rs`
+     (`pub use module::Type`), and consumers import the short `crate::Type`. TSE now tags `pub use`
+     with `ImportKind.REEXPORT`; `RustAnalyzer` emits a `NodeType.REEXPORT` carrier
+     (`crate::Type` → `crate::module::Type`) which `DependencyResolverService.applyRustReexportAliases`
+     folds into an **alias** on the real node (and drops the carrier) — so consumers resolve straight
+     to the definition with no forwarding-decoy cycles. This was explicitly out-of-scope originally;
+     implemented on request. SHCBarber result: 791→841 nodes, 1154→**2294 edges**, **0 cycles**,
+     non-test isolated 128→**59** (all legit value types/consts/string helpers; 0 bugs, 0 spurious).
+- **Hard ordering**: TSE PR 1 must merge **and tag a release** before this PR can be finalized
+  (against `v0.9.1`, `analyze(_, RUST)` throws `UnsupportedOperationException`). Use the composite
+  build (Task 1) to develop in parallel before the tag exists.
+- **No `TseMappings.kt` change expected** — TSE maps Rust items onto the existing `DeclarationType`
+  values (struct→CLASS, trait→INTERFACE, enum→ENUM, fn→FUNCTION, const/static→VARIABLE). If PR 1
+  ends up adding a new `DeclarationType`, extend `toNodeType()`; otherwise leave it untouched.
+- **Why `RustAnalyzer` ≠ `BaseLanguageAnalyzer`**: the base class assumes Class-1 (`packagePath`-driven
+  node paths, one self-wildcard from `packagePath`). Rust needs per-declaration `parentPath` paths
+  (Class-2) **and** a filesystem-derived file-module prefix — neither fits the base class, so it
+  follows `CSharpAnalyzer` directly. Revisit extracting shared Class-2 logic only if a third Class-2
+  language lands.
+- **No /dc-compare**: that tool diffs against DC main's legacy analyzer output; Rust has none. Unit
+  tests + manual `.cg.json` inspection are the validation path.
+- **Out of scope** (mirrors TSE PR 1 non-goals): macro-generated types, `#[cfg]` evaluation
+  (test modules included), re-export transitivity, function-body type usage, a Rust stdlib dictionary.
+
+## References
+
+- Class-2 analyzer template: `analysis/.../analyzers/csharp/CSharpAnalyzer.kt`
+- File-path→module derivation template: `analysis/.../analyzers/golang/queries/GoPackageQuery.kt`
+  (`derivePackagePathFromFilePath`), called from `golang/GoAnalyzer.kt`
+- `namespacePrefix` synthetic-wildcard precedent: `analysis/.../analyzers/cpp/CppAnalyzer.kt`
+- New-language precedent: `plans/2026-04-24-add-delphi-support.md`
+- Composite-build workflow: `plans/tse-typescript-javascript-integration.md`
+- TSE ↔ DC migration guidance: `CLAUDE.md` ("Migrating a Language Analyzer to TSE")
+- Producer (PR 1): `TreeSitterExcavationSite/plans/add-rust-dependency-support.md`
+</content>


### PR DESCRIPTION
Add Rust (.rs) as a supported language, delegating to the TreeSitterExcavationSite v0.11.0 dependency analysis (TreeSitterDependencies.analyze).

RustAnalyzer follows the Class-2 (multi-namespace) pattern with two Rust-specific concerns:
- crate-aware node paths: the crate directory before src/ is prepended, so cross-crate `use other_crate::Type` references resolve to the real definition instead of being dropped.
- `pub use` re-export flattening: a crate's lib.rs flattens its public API, so the REEXPORT carrier node is folded into an alias on the real definition by DependencyResolverService -- a consumer's `use crate::Type` then resolves straight to crate::module::Type, with no forwarding-decoy cycles.

Register RUST in SupportedLanguage, LanguageAnalyzerFactory, and the dependency resolver standard-library map; bump the TSE dependency to v0.11.0; update README, CLAUDE.md, the skill doc, and the changelog.

Validated on a real 10-crate Tauri workspace: 841 nodes, ~2.3k edges (~1.6k cross-crate), 0 cycles, no spurious or empty-named nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust dependency analysis for `.rs` files, including more accurate handling of `crate::`-style imports and cross-crate references.
  * Expanded supported language documentation and CLI feature descriptions to include Rust (and Delphi where applicable).

* **Bug Fixes**
  * Improved Rust `pub use` re-export processing and crate/module path resolution for more reliable dependency graphs.
  * Enhanced resolver behavior for Rust import mappings, resulting in fewer missing or incorrectly linked dependencies.

* **Documentation**
  * Updated DependaCharta skill and related docs to reflect the expanded Rust support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->